### PR TITLE
fix: ci fails on main

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -44,6 +44,7 @@ jobs:
         poetry run coverage xml -o coverage.xml
     - name: Test coverage report
       uses: orgoro/coverage@v3.1
+      if: github.event_name == "pull_request"
       with:
           coverageFile: ./coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -44,7 +44,7 @@ jobs:
         poetry run coverage xml -o coverage.xml
     - name: Test coverage report
       uses: orgoro/coverage@v3.1
-      if: ${{ github.event_name == "pull_request" }}
+      if: ${{ github.event_name == 'pull_request' }}
       with:
           coverageFile: ./coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -44,7 +44,7 @@ jobs:
         poetry run coverage xml -o coverage.xml
     - name: Test coverage report
       uses: orgoro/coverage@v3.1
-      if: github.event_name == "pull_request"
+      if: ${{ github.event_name == "pull_request" }}
       with:
           coverageFile: ./coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What?
ci fails on main branch

## Why?
code coverage report only works on a PR

## How?
`orgoro/coverage@v3.1` add a comment regarding the coverage report on a PR, it fails when done on main branch. To fix this issue, have to skip this step when running outside of a PR

## Testing?
run ci on both PR and main

