### PR TITLE
refactor: inject repositories rather than DB

### DIFF
--- a/pyfastapi/controllers/continent.py
+++ b/pyfastapi/controllers/continent.py
@@ -1,22 +1,19 @@
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.orm import Session
 
-from pyfastapi.repositories.continent import get_continent, get_continents
-from pyfastapi.libs.db import get_db
-
+from pyfastapi.repositories.continent import ContinentRepository
 
 router = APIRouter()
 
 
 @router.get("/")
-def get_all_continents(db: Session = Depends(get_db)):
-    continents = get_continents(db)
+def get_all_continents(repo: ContinentRepository = Depends(ContinentRepository)):
+    continents = repo.get_continents()
     return continents
 
 
 @router.get("/{code}")
-def get_one_continents(db: Session = Depends(get_db), code: str = None):
-    continent = get_continent(db, code)
+def get_one_continents(repo: ContinentRepository = Depends(ContinentRepository), code: str = None):
+    continent = repo.get_continent(code)
     if not continent:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Continent {code} not found")
     return continent

--- a/pyfastapi/controllers/country.py
+++ b/pyfastapi/controllers/country.py
@@ -1,24 +1,22 @@
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi_pagination import LimitOffsetPage
-from sqlalchemy.orm import Session
 
-from pyfastapi.repositories.country import get_countries, get_country
+from pyfastapi.repositories.country import CountryRepository
 from pyfastapi.schemas.country import CountryListSchema
-from pyfastapi.libs.db import get_db
 
 router = APIRouter()
 
 
 @router.get("/", response_model=LimitOffsetPage[CountryListSchema])
-def get_all_countries(db: Session = Depends(get_db)):
-    country = get_countries(db)
+def get_all_countries(repo: CountryRepository = Depends(CountryRepository)):
+    country = repo.get_countries()
     return country
 
 
 @router.get("/{code}")
-def get_one_country(db: Session = Depends(get_db), code: str = None):
-    country = get_country(db, code)
+def get_one_country(repo: CountryRepository = Depends(CountryRepository), code: str = None):
+    country = repo.get_country(code)
     if not country:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Country {code} not found")
     return country

--- a/pyfastapi/controllers/person.py
+++ b/pyfastapi/controllers/person.py
@@ -2,11 +2,9 @@ import traceback
 
 from fastapi import APIRouter, Depends, HTTPException, status, Response
 from fastapi_pagination import LimitOffsetPage
-from sqlalchemy.orm import Session
 
 from pyfastapi.models.person import Person
-from pyfastapi.repositories.person import get_person, get_persons, create_new_person, update_or_create_person
-from pyfastapi.libs.db import get_db
+from pyfastapi.repositories.person import PersonRepository
 from pyfastapi.schemas.person import PersonListSchema, PersonCreateSchema
 
 
@@ -14,21 +12,21 @@ router = APIRouter()
 
 
 @router.get("/", response_model=LimitOffsetPage[PersonListSchema])
-def get_all_persons(db: Session = Depends(get_db)):
-    person = get_persons(db)
+def get_all_persons(repo: PersonRepository = Depends(PersonRepository)):
+    person = repo.get_persons()
     return person
 
 
 @router.get("/{id_}")
-def get_one_persons(db: Session = Depends(get_db), id_: int = None):
-    person = get_person(db, id_)
+def get_one_persons(repo: PersonRepository = Depends(PersonRepository), id_: int = None):
+    person = repo.get_person(id_)
     if not person:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Person {id_} not found")
     return person
 
 
 @router.post("/", response_model=PersonListSchema)
-def create_person(body: PersonCreateSchema, db: Session = Depends(get_db)):
+def create_person(body: PersonCreateSchema, repo: PersonRepository = Depends(PersonRepository)):
     print("this is the body", body)
     try:
         person = Person(
@@ -36,7 +34,7 @@ def create_person(body: PersonCreateSchema, db: Session = Depends(get_db)):
             last_name=body.last_name,
             country_code=body.country_code
         )
-        new_person = create_new_person(db, person)
+        new_person = repo.create_new_person(person)
         return new_person
     except Exception as e:
         traceback.print_exc()
@@ -44,7 +42,7 @@ def create_person(body: PersonCreateSchema, db: Session = Depends(get_db)):
 
 
 @router.put("/{id_}")
-def update_person(id_: str, body: PersonCreateSchema, db: Session = Depends(get_db)):
+def update_person(id_: str, body: PersonCreateSchema, repo: PersonRepository = Depends(PersonRepository)):
     person = Person(
         first_name=body.first_name,
         last_name=body.last_name,
@@ -52,5 +50,5 @@ def update_person(id_: str, body: PersonCreateSchema, db: Session = Depends(get_
     )
     person.id = int(id_)
     print("updating", person)
-    update_or_create_person(db, person)
+    repo.update_or_create_person(person)
     return Response(status_code=204)

--- a/pyfastapi/repositories/base.py
+++ b/pyfastapi/repositories/base.py
@@ -1,9 +1,10 @@
+from abc import ABC
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from pyfastapi.libs.db import get_db
 
 
-class BaseRepository:
+class BaseRepository(ABC):
     def __init__(self, db: Session = Depends(get_db)):
         self.db = db

--- a/pyfastapi/repositories/base.py
+++ b/pyfastapi/repositories/base.py
@@ -1,0 +1,9 @@
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from pyfastapi.libs.db import get_db
+
+
+class BaseRepository:
+    def __init__(self, db: Session = Depends(get_db)):
+        self.db = db

--- a/pyfastapi/repositories/continent.py
+++ b/pyfastapi/repositories/continent.py
@@ -1,11 +1,12 @@
 
+from .base import BaseRepository
 from pyfastapi.models.continent import Continent
-from sqlalchemy.orm import Session
 
 
-def get_continent(db: Session, code: str):
-    return db.query(Continent).filter(Continent.code == code).first()
+class ContinentRepository(BaseRepository):
 
+    def get_continent(self, code: str):
+        return self.db.query(Continent).filter(Continent.code == code).first()
 
-def get_continents(db: Session):
-    return db.query(Continent).all()
+    def get_continents(self):
+        return self.db.query(Continent).all()

--- a/pyfastapi/repositories/country.py
+++ b/pyfastapi/repositories/country.py
@@ -1,12 +1,14 @@
-
-from pyfastapi.models.country import Country
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import joinedload
 from fastapi_pagination.ext.sqlalchemy import paginate
 
+from .base import BaseRepository
+from pyfastapi.models.country import Country
 
-def get_country(db: Session, code: str):
-    return db.query(Country).options(joinedload(Country.continent)).filter(Country.code == code).first()
 
+class CountryRepository(BaseRepository):
 
-def get_countries(db: Session):
-    return paginate(db.query(Country))
+    def get_country(self, code: str):
+        return self.db.query(Country).options(joinedload(Country.continent)).filter(Country.code == code).first()
+
+    def get_countries(self):
+        return paginate(self.db.query(Country))

--- a/pyfastapi/repositories/person.py
+++ b/pyfastapi/repositories/person.py
@@ -1,28 +1,26 @@
-from pyfastapi.schemas.person import PersonSchema
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import joinedload
 from fastapi_pagination.ext.sqlalchemy import paginate
 
+from .base import BaseRepository
 from pyfastapi.models.person import Person
 from pyfastapi.models.country import Country
 
 
-def get_person(db: Session, id_: int):
-    return (db.query(Person)
-            .options(joinedload(Person.country).joinedload(Country.continent))
-            .filter(Person.id == id_).first())
+class PersonRepository(BaseRepository):
+    def get_person(self, id_: int):
+        return (self.db.query(Person)
+                .options(joinedload(Person.country).joinedload(Country.continent))
+                .filter(Person.id == id_).first())
 
+    def get_persons(self):
+        return paginate(self.db.query(Person))
 
-def get_persons(db: Session):
-    return paginate(db.query(Person))
+    def create_new_person(self, person: Person):
+        self.db.add(person)
+        self.db.commit()
+        self.db.refresh(person)
+        return person
 
-
-def create_new_person(db: Session, person: Person):
-    db.add(person)
-    db.commit()
-    db.refresh(person)
-    return person
-
-
-def update_or_create_person(db: Session, person: Person):
-    db.merge(person)
-    db.commit()
+    def update_or_create_person(self, person: Person):
+        self.db.merge(person)
+        self.db.commit()


### PR DESCRIPTION
## What?
inject repositories rather than DB

## Why?
injecting DB into controller mothods then injecting DB classes into repository methods it not clean code

## How?
Transform repositories into class so that fastapi can inject the DB into it, and then inject repository classes into controller methods makes it cleaner

## Testing?
integration tests pass

## Anything Else?
