### PR TITLE
fix: pydantic and sqlalchemy warnings

### DIFF
--- a/pyfastapi/controllers/continent.py
+++ b/pyfastapi/controllers/continent.py
@@ -1,17 +1,21 @@
+from typing import List
+
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from pyfastapi.repositories import ContinentRepository
+from pyfastapi.schemas import ContinentSchema
 
 router = APIRouter()
 
 
-@router.get("/")
+@router.get("/", response_model=List[ContinentSchema])
 def get_all_continents(repo: ContinentRepository = Depends(ContinentRepository)):
     continents = repo.get_continents()
+    print("this is", continents)
     return continents
 
 
-@router.get("/{code}")
+@router.get("/{code}", response_model=ContinentSchema)
 def get_one_continents(repo: ContinentRepository = Depends(ContinentRepository), code: str = None):
     continent = repo.get_continent(code)
     if not continent:

--- a/pyfastapi/controllers/country.py
+++ b/pyfastapi/controllers/country.py
@@ -13,7 +13,7 @@ def get_all_countries(repo: CountryRepository = Depends(CountryRepository)):
     return country
 
 
-@router.get("/{code}")
+@router.get("/{code}", response_model=CountryListSchema)
 def get_one_country(repo: CountryRepository = Depends(CountryRepository), code: str = None):
     country = repo.get_country(code)
     if not country:

--- a/pyfastapi/libs/db.py
+++ b/pyfastapi/libs/db.py
@@ -1,6 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, declarative_base
 
 from pyfastapi.config import config
 

--- a/pyfastapi/repositories/continent.py
+++ b/pyfastapi/repositories/continent.py
@@ -1,3 +1,5 @@
+from sqlalchemy.sql import select
+
 from .base import BaseRepository
 from pyfastapi.models.continent import Continent
 
@@ -5,7 +7,7 @@ from pyfastapi.models.continent import Continent
 class ContinentRepository(BaseRepository):
 
     def get_continent(self, code: str):
-        return self.db.query(Continent).filter(Continent.code == code).first()
+        return self.db.execute(select(Continent).where(Continent.code == code)).scalar_one_or_none()
 
     def get_continents(self):
-        return self.db.query(Continent).all()
+        return self.db.execute(select(Continent)).scalars()

--- a/pyfastapi/repositories/country.py
+++ b/pyfastapi/repositories/country.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import joinedload
 from fastapi_pagination.ext.sqlalchemy import paginate
+from sqlalchemy.sql import select
 
 from .base import BaseRepository
 from pyfastapi.models.country import Country
@@ -8,7 +9,10 @@ from pyfastapi.models.country import Country
 class CountryRepository(BaseRepository):
 
     def get_country(self, code: str):
-        return self.db.query(Country).options(joinedload(Country.continent)).filter(Country.code == code).first()
+
+        return self.db.execute(
+            select(Country).options(joinedload(Country.continent)).where(Country.code == code)
+        ).scalar_one_or_none()
 
     def get_countries(self):
-        return paginate(self.db.query(Country))
+        return paginate(self.db, select(Country))

--- a/pyfastapi/repositories/person.py
+++ b/pyfastapi/repositories/person.py
@@ -1,4 +1,5 @@
 from sqlalchemy.orm import joinedload
+from sqlalchemy.sql import select
 from fastapi_pagination.ext.sqlalchemy import paginate
 
 from .base import BaseRepository
@@ -8,12 +9,12 @@ from pyfastapi.models.country import Country
 
 class PersonRepository(BaseRepository):
     def get_person(self, id_: int):
-        return (self.db.query(Person)
+        return (self.db.execute(select(Person)
                 .options(joinedload(Person.country).joinedload(Country.continent))
-                .filter(Person.id == id_).first())
+                .where(Person.id == id_)).scalar_one_or_none())
 
     def get_persons(self):
-        return paginate(self.db.query(Person))
+        return paginate(self.db, select(Person))
 
     def create_new_person(self, person: Person):
         self.db.add(person)

--- a/pyfastapi/schemas/continent.py
+++ b/pyfastapi/schemas/continent.py
@@ -6,5 +6,6 @@ class ContinentSchema(BaseModel):
     code: str
     name: str
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True
+    }

--- a/pyfastapi/schemas/country.py
+++ b/pyfastapi/schemas/country.py
@@ -13,8 +13,9 @@ class CountryBaseSchema(BaseModel):
     currency: str
     alpha_3: str
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True
+    }
 
 
 class CountrySchema(CountryBaseSchema):

--- a/pyfastapi/schemas/person.py
+++ b/pyfastapi/schemas/person.py
@@ -8,8 +8,9 @@ class PersonBaseSchema(BaseModel):
     last_name: str = Field(default=None)
     first_name: str
 
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True
+    }
 
 
 class PersonSchema(PersonBaseSchema):


### PR DESCRIPTION
## What?
use v2 syntax for pydantic and sqlalchemy

## Why?
v1 api will be deprecated eventually for both

## How?
modify how they are called

## Testing?
yes
