### PR TITLE
feat: configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,4 @@
 DB_HOST=sqlite:///./sql_app.db
+HOST=0.0.0.0
+PORT=5000
+LOG_LEVEL=debug

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -3,12 +3,12 @@ from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 from alembic import context
 
-from pyfastapi.config import config as app_config
+from pyfastapi.config import Config as AppConfig
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-config.set_main_option("sqlalchemy.url", app_config["DB_HOST"])
+config.set_main_option("sqlalchemy.url", AppConfig.DB_HOST)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/pyfastapi/config.py
+++ b/pyfastapi/config.py
@@ -3,6 +3,9 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-config = {
-    "DB_HOST": environ.get("DB_HOST"),
-}
+
+class Config:
+    DB_HOST = environ.get("DB_HOST", "sqlite:///./sql_app.db")
+    HOST = environ.get("HOST", "0.0.0.0")
+    PORT = int(environ.get("PORT", "5000"))
+    LOG_LEVEL = environ.get("LOG_LEVEL", "debug")

--- a/pyfastapi/libs/db.py
+++ b/pyfastapi/libs/db.py
@@ -1,10 +1,10 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
 
-from pyfastapi.config import config
+from pyfastapi.config import Config
 
 
-SQLALCHEMY_DATABASE_URL = config.get("DB_HOST")
+SQLALCHEMY_DATABASE_URL = Config.DB_HOST
 
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}

--- a/run.py
+++ b/run.py
@@ -1,6 +1,8 @@
-from pyfastapi.main import app
 import uvicorn
+
+from pyfastapi.config import Config
+from pyfastapi.main import app
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=5000, log_level="debug")
+    uvicorn.run(app, host=Config.HOST, port=Config.PORT, log_level=Config.LOG_LEVEL)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,9 +20,9 @@ def init_db():
     this is equivalent to "alembic upgrade head" then run "alembic downgrade base" after 1 test is done
     runs every test to make sure we have a clean set of data
     """
-    from pyfastapi.config import config as app_config
+    from pyfastapi.config import Config as AppConfig
     config = Config()
-    config.set_main_option("sqlalchemy.url", app_config["DB_HOST"])
+    config.set_main_option("sqlalchemy.url", AppConfig.DB_HOST)
     config.set_main_option("script_location", "alembic")
     command.upgrade(config, 'head')
     yield None


### PR DESCRIPTION
## What?
add more configuration through env

## Why?
configurations should not be hardcoded

## How?
have a config class to read env variables

## Testing?

## Anything Else?
it will be a good idea to use class so that users can do `Config.DB_HOST` rather than `config["DB_HOST"]`, less typo this way
