### PR TITLE
refactor: enable static typing

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,6 +38,9 @@ jobs:
         poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Run mypy
+      run: |
+        poetry run mypy --strict .
     - name: Test with pytest
       run: |
         poetry run coverage run --source=pyfastapi -m pytest

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,9 +1,11 @@
 from logging.config import fileConfig
+
+from alembic import context
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
-from alembic import context
 
 from pyfastapi.config import get_config
+
 AppConfig = get_config()
 
 # this is the Alembic Config object, which provides

--- a/alembic/versions/602af0699ee9_init_persons_and_country_db.py
+++ b/alembic/versions/602af0699ee9_init_persons_and_country_db.py
@@ -5,8 +5,8 @@ Revises:
 Create Date: 2023-07-31 12:05:29.431998
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '602af0699ee9'

--- a/poetry.lock
+++ b/poetry.lock
@@ -603,6 +603,63 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.8.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:485a8942f671120f76afffff70f259e1cd0f0cfe08f81c05d8816d958d4577d3"},
+    {file = "mypy-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:df9824ac11deaf007443e7ed2a4a26bebff98d2bc43c6da21b2b64185da011c4"},
+    {file = "mypy-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2afecd6354bbfb6e0160f4e4ad9ba6e4e003b767dd80d85516e71f2e955ab50d"},
+    {file = "mypy-1.8.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8963b83d53ee733a6e4196954502b33567ad07dfd74851f32be18eb932fb1cb9"},
+    {file = "mypy-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:e46f44b54ebddbeedbd3d5b289a893219065ef805d95094d16a0af6630f5d410"},
+    {file = "mypy-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:855fe27b80375e5c5878492f0729540db47b186509c98dae341254c8f45f42ae"},
+    {file = "mypy-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4c886c6cce2d070bd7df4ec4a05a13ee20c0aa60cb587e8d1265b6c03cf91da3"},
+    {file = "mypy-1.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d19c413b3c07cbecf1f991e2221746b0d2a9410b59cb3f4fb9557f0365a1a817"},
+    {file = "mypy-1.8.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:9261ed810972061388918c83c3f5cd46079d875026ba97380f3e3978a72f503d"},
+    {file = "mypy-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:51720c776d148bad2372ca21ca29256ed483aa9a4cdefefcef49006dff2a6835"},
+    {file = "mypy-1.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:52825b01f5c4c1c4eb0db253ec09c7aa17e1a7304d247c48b6f3599ef40db8bd"},
+    {file = "mypy-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f5ac9a4eeb1ec0f1ccdc6f326bcdb464de5f80eb07fb38b5ddd7b0de6bc61e55"},
+    {file = "mypy-1.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afe3fe972c645b4632c563d3f3eff1cdca2fa058f730df2b93a35e3b0c538218"},
+    {file = "mypy-1.8.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:42c6680d256ab35637ef88891c6bd02514ccb7e1122133ac96055ff458f93fc3"},
+    {file = "mypy-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:720a5ca70e136b675af3af63db533c1c8c9181314d207568bbe79051f122669e"},
+    {file = "mypy-1.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:028cf9f2cae89e202d7b6593cd98db6759379f17a319b5faf4f9978d7084cdc6"},
+    {file = "mypy-1.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4e6d97288757e1ddba10dd9549ac27982e3e74a49d8d0179fc14d4365c7add66"},
+    {file = "mypy-1.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f1478736fcebb90f97e40aff11a5f253af890c845ee0c850fe80aa060a267c6"},
+    {file = "mypy-1.8.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:42419861b43e6962a649068a61f4a4839205a3ef525b858377a960b9e2de6e0d"},
+    {file = "mypy-1.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:2b5b6c721bd4aabaadead3a5e6fa85c11c6c795e0c81a7215776ef8afc66de02"},
+    {file = "mypy-1.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5c1538c38584029352878a0466f03a8ee7547d7bd9f641f57a0f3017a7c905b8"},
+    {file = "mypy-1.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4ef4be7baf08a203170f29e89d79064463b7fc7a0908b9d0d5114e8009c3a259"},
+    {file = "mypy-1.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7178def594014aa6c35a8ff411cf37d682f428b3b5617ca79029d8ae72f5402b"},
+    {file = "mypy-1.8.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:ab3c84fa13c04aeeeabb2a7f67a25ef5d77ac9d6486ff33ded762ef353aa5592"},
+    {file = "mypy-1.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:99b00bc72855812a60d253420d8a2eae839b0afa4938f09f4d2aa9bb4654263a"},
+    {file = "mypy-1.8.0-py3-none-any.whl", hash = "sha256:538fd81bb5e430cc1381a443971c0475582ff9f434c16cd46d2c66763ce85d9d"},
+    {file = "mypy-1.8.0.tar.gz", hash = "sha256:6ff8b244d7085a0b425b56d327b480c3b29cafbd2eff27316a004f9a7391ae07"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "orjson"
 version = "3.9.12"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
@@ -1424,4 +1481,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "6b650a6b8f1a86008b2b0a6e5c5e54f20910557bc92136d26431f0fada95ab8e"
+content-hash = "71c7a38dc8f5907cc8178b9c33bcc64a5343a7a168a52c5af180a0a6f4968bd1"

--- a/pyfastapi/config.py
+++ b/pyfastapi/config.py
@@ -19,6 +19,11 @@ class Settings(BaseSettings):
 
 @lru_cache
 def get_config() -> Settings:
+    """
+    Get the configuration settings
+    This will check if it is running on pytest.
+    If it is, it will use the .env.test file, otherwise it will use the .env file
+    """
     file = ".env.test" if "pytest" in sys.modules else ".env"
     print('input file', file)
     return Settings(_env_file=file)

--- a/pyfastapi/config.py
+++ b/pyfastapi/config.py
@@ -1,18 +1,25 @@
+import sys
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from functools import lru_cache
 
 
 class Settings(BaseSettings):
+
+    def __init__(self, _env_file: str) -> None:
+        super().__init__(_env_file=_env_file)
+
     DB_HOST: str = "sqlite:///./sql_app.db"
     HOST: str = "0.0.0.0"
     PORT: int = 5000
     LOG_LEVEL: str = "debug"
 
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict()
 
 
 @lru_cache
-def get_config(file=".env") -> Settings:
+def get_config() -> Settings:
+    file = ".env.test" if "pytest" in sys.modules else ".env"
+    print('input file', file)
     return Settings(_env_file=file)
 
 

--- a/pyfastapi/config.py
+++ b/pyfastapi/config.py
@@ -1,6 +1,7 @@
 import sys
-from pydantic_settings import BaseSettings, SettingsConfigDict
 from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):

--- a/pyfastapi/controllers/continent.py
+++ b/pyfastapi/controllers/continent.py
@@ -1,7 +1,8 @@
 from typing import List, Annotated
+from sqlalchemy import ScalarResult
+from fastapi import APIRouter, Depends, HTTPException, status, Path
 
-from fastapi import APIRouter, Depends, HTTPException, status
-
+from pyfastapi.models import Continent
 from pyfastapi.repositories import ContinentRepository
 from pyfastapi.schemas import ContinentSchema
 
@@ -9,13 +10,16 @@ router = APIRouter()
 
 
 @router.get("/", response_model=List[ContinentSchema])
-def get_all_continents(repo: Annotated[ContinentRepository, Depends()]):
+def get_all_continents(repo: Annotated[ContinentRepository, Depends()]) -> ScalarResult[Continent]:
     continents = repo.get_continents()
     return continents
 
 
 @router.get("/{code}", response_model=ContinentSchema)
-def get_one_continents(repo: Annotated[ContinentRepository, Depends()], code: str = None):
+def get_one_continents(
+    repo: Annotated[ContinentRepository, Depends()],
+    code: Annotated[str, Path(title="continent code")]
+) -> Continent:
     continent = repo.get_continent(code)
     if not continent:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Continent {code} not found")

--- a/pyfastapi/controllers/continent.py
+++ b/pyfastapi/controllers/continent.py
@@ -1,6 +1,7 @@
 from typing import List, Annotated
-from sqlalchemy import ScalarResult
+
 from fastapi import APIRouter, Depends, HTTPException, status, Path
+from sqlalchemy import ScalarResult
 
 from pyfastapi.models import Continent
 from pyfastapi.repositories import ContinentRepository

--- a/pyfastapi/controllers/country.py
+++ b/pyfastapi/controllers/country.py
@@ -1,7 +1,8 @@
 from typing import Annotated
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status, Path
 from fastapi_pagination import LimitOffsetPage
 
+from pyfastapi.models import Country
 from pyfastapi.repositories import CountryRepository
 from pyfastapi.schemas import CountryListSchema
 
@@ -9,13 +10,16 @@ router = APIRouter()
 
 
 @router.get("/", response_model=LimitOffsetPage[CountryListSchema])
-def get_all_countries(repo: Annotated[CountryRepository, Depends()]):
+def get_all_countries(repo: Annotated[CountryRepository, Depends()]) -> LimitOffsetPage[Country]:
     country = repo.get_countries()
     return country
 
 
 @router.get("/{code}", response_model=CountryListSchema)
-def get_one_country(repo: Annotated[CountryRepository, Depends()], code: str = None):
+def get_one_country(
+    repo: Annotated[CountryRepository, Depends()],
+    code: Annotated[str, Path(title="country code")]
+) -> Country:
     country = repo.get_country(code)
     if not country:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Country {code} not found")

--- a/pyfastapi/controllers/country.py
+++ b/pyfastapi/controllers/country.py
@@ -1,4 +1,5 @@
 from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException, status, Path
 from fastapi_pagination import LimitOffsetPage
 

--- a/pyfastapi/controllers/person.py
+++ b/pyfastapi/controllers/person.py
@@ -1,6 +1,6 @@
 import traceback
 from typing import Annotated
-from fastapi import APIRouter, Depends, HTTPException, status, Response
+from fastapi import APIRouter, Depends, HTTPException, Response, status, Path
 from fastapi_pagination import LimitOffsetPage
 
 from pyfastapi.models import Person
@@ -12,13 +12,16 @@ router = APIRouter()
 
 
 @router.get("/", response_model=LimitOffsetPage[PersonListSchema])
-def get_all_persons(repo: Annotated[PersonRepository, Depends()]):
+def get_all_persons(repo: Annotated[PersonRepository, Depends()]) -> LimitOffsetPage[Person]:
     person = repo.get_persons()
     return person
 
 
-@router.get("/{id_}")
-def get_one_persons(repo: Annotated[PersonRepository, Depends()], id_: int = None):
+@router.get("/{id_}", response_model=PersonListSchema)
+def get_one_persons(
+    repo: Annotated[PersonRepository, Depends()],
+    id_: Annotated[int, Path(title="person id")]
+) -> Person:
     person = repo.get_person(id_)
     if not person:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=f"Person {id_} not found")
@@ -26,7 +29,7 @@ def get_one_persons(repo: Annotated[PersonRepository, Depends()], id_: int = Non
 
 
 @router.post("/", response_model=PersonListSchema)
-def create_person(body: PersonCreateSchema, repo: Annotated[PersonRepository, Depends()]):
+def create_person(body: PersonCreateSchema, repo: Annotated[PersonRepository, Depends()]) -> Person:
     try:
         person = Person(
             first_name=body.first_name,
@@ -41,7 +44,11 @@ def create_person(body: PersonCreateSchema, repo: Annotated[PersonRepository, De
 
 
 @router.put("/{id_}")
-def update_person(id_: str, body: PersonCreateSchema, repo: Annotated[PersonRepository, Depends()]):
+def update_person(
+    id_: Annotated[int, Path(title="person id")],
+    body: PersonCreateSchema,
+    repo: Annotated[PersonRepository, Depends()]
+) -> Response:
     person = Person(
         first_name=body.first_name,
         last_name=body.last_name,

--- a/pyfastapi/controllers/person.py
+++ b/pyfastapi/controllers/person.py
@@ -1,12 +1,12 @@
 import traceback
 from typing import Annotated
+
 from fastapi import APIRouter, Depends, HTTPException, Response, status, Path
 from fastapi_pagination import LimitOffsetPage
 
 from pyfastapi.models import Person
 from pyfastapi.repositories import PersonRepository
 from pyfastapi.schemas import PersonListSchema, PersonCreateSchema
-
 
 router = APIRouter()
 

--- a/pyfastapi/controllers/person.py
+++ b/pyfastapi/controllers/person.py
@@ -6,7 +6,7 @@ from fastapi_pagination import LimitOffsetPage
 
 from pyfastapi.models import Person
 from pyfastapi.repositories import PersonRepository
-from pyfastapi.schemas import PersonListSchema, PersonCreateSchema
+from pyfastapi.schemas import PersonListSchema, PersonCreateSchema, PersonSchema
 
 router = APIRouter()
 
@@ -17,7 +17,7 @@ def get_all_persons(repo: Annotated[PersonRepository, Depends()]) -> LimitOffset
     return person
 
 
-@router.get("/{id_}", response_model=PersonListSchema)
+@router.get("/{id_}", response_model=PersonSchema)
 def get_one_persons(
     repo: Annotated[PersonRepository, Depends()],
     id_: Annotated[int, Path(title="person id")]

--- a/pyfastapi/libs/__init__.py
+++ b/pyfastapi/libs/__init__.py
@@ -1,3 +1,3 @@
-from .db import get_db, Base
+from .db import get_db
 
-__all__ = ["get_db", "Base"]
+__all__ = ["get_db"]

--- a/pyfastapi/libs/db.py
+++ b/pyfastapi/libs/db.py
@@ -1,9 +1,9 @@
 from typing import Iterator
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 
 from pyfastapi.config import get_config
-
 
 SQLALCHEMY_DATABASE_URL = get_config().DB_HOST
 print("db", SQLALCHEMY_DATABASE_URL)

--- a/pyfastapi/libs/db.py
+++ b/pyfastapi/libs/db.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker, Session
 from pyfastapi.config import get_config
 
 SQLALCHEMY_DATABASE_URL = get_config().DB_HOST
-print("db", SQLALCHEMY_DATABASE_URL)
+
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
 )

--- a/pyfastapi/libs/db.py
+++ b/pyfastapi/libs/db.py
@@ -1,20 +1,19 @@
+from typing import Iterator
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.orm import sessionmaker, Session
 
 from pyfastapi.config import get_config
 
 
 SQLALCHEMY_DATABASE_URL = get_config().DB_HOST
-
+print("db", SQLALCHEMY_DATABASE_URL)
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-Base = declarative_base()
-Base.metadata.create_all(bind=engine)
 
 
-def get_db():
+def get_db() -> Iterator[Session]:
     db = SessionLocal()
     try:
         yield db

--- a/pyfastapi/main.py
+++ b/pyfastapi/main.py
@@ -1,3 +1,5 @@
+from typing import Coroutine, Any
+
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.encoders import jsonable_encoder
@@ -9,12 +11,16 @@ from pyfastapi.controllers import person_router, country_router, continent_route
 app = FastAPI()
 
 
+async def health() -> JSONResponse:
+    return JSONResponse({"status": "ok"})
+
+
 app.include_router(person_router, prefix="/persons")
 app.include_router(country_router, prefix="/countries")
 app.include_router(continent_router, prefix="/continents")
 app.add_api_route(
     "/health",
-    endpoint=lambda: JSONResponse(content=jsonable_encoder({"status": "ok"})),
+    endpoint=health,
     methods=["GET"]
 )
 

--- a/pyfastapi/main.py
+++ b/pyfastapi/main.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from fastapi_pagination import add_pagination
 
 from pyfastapi.controllers import person_router, country_router, continent_router
@@ -12,7 +14,7 @@ app.include_router(country_router, prefix="/countries")
 app.include_router(continent_router, prefix="/continents")
 app.add_api_route(
     "/health",
-    endpoint=lambda: {"status": "ok"},
+    endpoint=lambda: JSONResponse(content=jsonable_encoder({"status": "ok"})),
     methods=["GET"]
 )
 

--- a/pyfastapi/main.py
+++ b/pyfastapi/main.py
@@ -1,12 +1,8 @@
-from typing import Coroutine, Any
-
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
-from fastapi.encoders import jsonable_encoder
 from fastapi_pagination import add_pagination
 
 from pyfastapi.controllers import person_router, country_router, continent_router
-
 
 app = FastAPI()
 

--- a/pyfastapi/models/base.py
+++ b/pyfastapi/models/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/pyfastapi/models/continent.py
+++ b/pyfastapi/models/continent.py
@@ -1,20 +1,20 @@
-from sqlalchemy import Column, String
-from sqlalchemy.orm import Relationship
+from typing import TYPE_CHECKING
+from sqlalchemy import String
+from sqlalchemy.orm import relationship, Mapped, mapped_column
 
-from pyfastapi.libs import Base
+from .base import Base
+
+if TYPE_CHECKING:
+    from .country import Country
 
 
 class Continent(Base):
     __tablename__ = "continents"
 
-    code = Column(String(2), primary_key=True)
-    name = Column(String(100), nullable=False)
+    code: Mapped[str] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
 
-    country = Relationship("Country", back_populates="continent")
+    country: Mapped["Country"] = relationship(back_populates="continent")
 
-    def __init__(self, code, name):
-        self.code = code
-        self.name = name
-
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Continent('{self.code}, {self.name}')"

--- a/pyfastapi/models/continent.py
+++ b/pyfastapi/models/continent.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+
 from sqlalchemy import String
 from sqlalchemy.orm import relationship, Mapped, mapped_column
 

--- a/pyfastapi/models/country.py
+++ b/pyfastapi/models/country.py
@@ -1,33 +1,28 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
-from sqlalchemy.orm import Relationship, deferred
+from typing import TYPE_CHECKING
+from sqlalchemy import Integer, String, ForeignKey
+from sqlalchemy.orm import relationship, deferred, Mapped, mapped_column
 
-from pyfastapi.libs import Base
+from .base import Base
+
+if TYPE_CHECKING:
+    from .person import Person
+    from .continent import Continent
 
 
 class Country(Base):
     __tablename__ = "countries"
 
-    code = Column(String(2), primary_key=True)
-    name = Column(String(100), nullable=False)
-    phone = Column(Integer, nullable=False)
-    symbol = Column(String(10))
-    capital = Column(String(80))
-    currency = Column(String(3))
-    continent_code = deferred(Column(String(2), ForeignKey("continents.code")))
-    alpha_3 = Column(String(3))
+    code: Mapped[str] = mapped_column(String(2), primary_key=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    phone: Mapped[int] = mapped_column(Integer, nullable=False)
+    symbol: Mapped[str] = mapped_column(String(10))
+    capital: Mapped[str] = mapped_column(String(80))
+    currency: Mapped[str] = mapped_column(String(3))
+    continent_code: Mapped[str] = deferred(mapped_column(String(2), ForeignKey("continents.code")))
+    alpha_3: Mapped[str] = mapped_column(String(3))
 
-    person = Relationship("Person", back_populates="country")
-    continent = Relationship("Continent", back_populates="country")
+    person: Mapped["Person"] = relationship(back_populates="country")
+    continent: Mapped["Continent"] = relationship(back_populates="country")
 
-    def __init__(self, code, name, phone, symbol, capital, currency, continent_code, alpha_3):
-        self.code = code
-        self.name = name
-        self.phone = phone
-        self.symbol = symbol
-        self.capital = capital
-        self.currency = currency
-        self.continent_code = continent_code
-        self.alpha_3 = alpha_3
-
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Country('{self.code}, {self.name}')"

--- a/pyfastapi/models/country.py
+++ b/pyfastapi/models/country.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+
 from sqlalchemy import Integer, String, ForeignKey
 from sqlalchemy.orm import relationship, deferred, Mapped, mapped_column
 

--- a/pyfastapi/models/person.py
+++ b/pyfastapi/models/person.py
@@ -1,4 +1,5 @@
 from typing import TYPE_CHECKING
+
 from sqlalchemy import Integer, String, ForeignKey
 from sqlalchemy.orm import relationship, deferred, mapped_column, Mapped
 

--- a/pyfastapi/models/person.py
+++ b/pyfastapi/models/person.py
@@ -1,23 +1,22 @@
-from sqlalchemy import Column, Integer, String, ForeignKey
-from sqlalchemy.orm import relationship, deferred
+from typing import TYPE_CHECKING
+from sqlalchemy import Integer, String, ForeignKey
+from sqlalchemy.orm import relationship, deferred, mapped_column, Mapped
 
-from pyfastapi.libs import Base
+from .base import Base
+
+if TYPE_CHECKING:
+    from .country import Country
 
 
 class Person(Base):
     __tablename__ = "persons"
 
-    id = Column(Integer, primary_key=True)
-    last_name = Column(String(100), nullable=True)
-    first_name = Column(String(100), nullable=False)
-    country_code = deferred(Column(String(2), ForeignKey("countries.code")))
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    last_name: Mapped[str] = mapped_column(String(100), nullable=True)
+    first_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    country_code: Mapped[str] = deferred(mapped_column(String(2), ForeignKey("countries.code")))
 
-    country = relationship("Country", back_populates="person")
+    country: Mapped["Country"] = relationship(back_populates="person")
 
-    def __init__(self, last_name, first_name, country_code):
-        self.last_name = last_name
-        self.first_name = first_name
-        self.country_code = country_code
-
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Person('{self.id}, {self.first_name}, {self.last_name}')"

--- a/pyfastapi/repositories/base.py
+++ b/pyfastapi/repositories/base.py
@@ -1,5 +1,6 @@
 from abc import ABC
 from typing import Annotated
+
 from fastapi import Depends
 from sqlalchemy.orm import Session
 

--- a/pyfastapi/repositories/continent.py
+++ b/pyfastapi/repositories/continent.py
@@ -1,3 +1,5 @@
+from typing import List
+from sqlalchemy import ScalarResult
 from sqlalchemy.sql import select
 
 from .base import BaseRepository
@@ -6,8 +8,8 @@ from pyfastapi.models.continent import Continent
 
 class ContinentRepository(BaseRepository):
 
-    def get_continent(self, code: str):
+    def get_continent(self, code: str) -> Continent | None:
         return self.db.execute(select(Continent).where(Continent.code == code)).scalar_one_or_none()
 
-    def get_continents(self):
+    def get_continents(self) -> ScalarResult[Continent]:
         return self.db.execute(select(Continent)).scalars()

--- a/pyfastapi/repositories/continent.py
+++ b/pyfastapi/repositories/continent.py
@@ -1,9 +1,8 @@
-from typing import List
 from sqlalchemy import ScalarResult
 from sqlalchemy.sql import select
 
-from .base import BaseRepository
 from pyfastapi.models.continent import Continent
+from .base import BaseRepository
 
 
 class ContinentRepository(BaseRepository):

--- a/pyfastapi/repositories/continent.py
+++ b/pyfastapi/repositories/continent.py
@@ -1,14 +1,15 @@
 from sqlalchemy import ScalarResult
 from sqlalchemy.sql import select
 
-from pyfastapi.models.continent import Continent
+from pyfastapi.models import Continent
 from .base import BaseRepository
 
 
 class ContinentRepository(BaseRepository):
 
     def get_continent(self, code: str) -> Continent | None:
-        return self.db.execute(select(Continent).where(Continent.code == code)).scalar_one_or_none()
+        stmt = select(Continent).where(Continent.code == code)
+        return self.db.execute(stmt).scalar_one_or_none()
 
     def get_continents(self) -> ScalarResult[Continent]:
         return self.db.execute(select(Continent)).scalars()

--- a/pyfastapi/repositories/country.py
+++ b/pyfastapi/repositories/country.py
@@ -1,3 +1,4 @@
+from fastapi_pagination import LimitOffsetPage
 from sqlalchemy.orm import joinedload
 from fastapi_pagination.ext.sqlalchemy import paginate
 from sqlalchemy.sql import select
@@ -8,11 +9,11 @@ from pyfastapi.models.country import Country
 
 class CountryRepository(BaseRepository):
 
-    def get_country(self, code: str):
-
+    def get_country(self, code: str) -> Country | None:
         return self.db.execute(
             select(Country).options(joinedload(Country.continent)).where(Country.code == code)
         ).scalar_one_or_none()
 
-    def get_countries(self):
-        return paginate(self.db, select(Country))
+    def get_countries(self) -> LimitOffsetPage[Country]:
+        country_list: LimitOffsetPage[Country] = paginate(self.db, select(Country))
+        return country_list

--- a/pyfastapi/repositories/country.py
+++ b/pyfastapi/repositories/country.py
@@ -3,16 +3,15 @@ from fastapi_pagination.ext.sqlalchemy import paginate
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 
-from pyfastapi.models.country import Country
+from pyfastapi.models import Country
 from .base import BaseRepository
 
 
 class CountryRepository(BaseRepository):
 
     def get_country(self, code: str) -> Country | None:
-        return self.db.execute(
-            select(Country).options(joinedload(Country.continent)).where(Country.code == code)
-        ).scalar_one_or_none()
+        stmt = select(Country).options(joinedload(Country.continent)).where(Country.code == code)
+        return self.db.execute(stmt).scalar_one_or_none()
 
     def get_countries(self) -> LimitOffsetPage[Country]:
         country_list: LimitOffsetPage[Country] = paginate(self.db, select(Country))

--- a/pyfastapi/repositories/country.py
+++ b/pyfastapi/repositories/country.py
@@ -1,10 +1,10 @@
 from fastapi_pagination import LimitOffsetPage
-from sqlalchemy.orm import joinedload
 from fastapi_pagination.ext.sqlalchemy import paginate
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 
-from .base import BaseRepository
 from pyfastapi.models.country import Country
+from .base import BaseRepository
 
 
 class CountryRepository(BaseRepository):

--- a/pyfastapi/repositories/person.py
+++ b/pyfastapi/repositories/person.py
@@ -1,18 +1,15 @@
 from fastapi_pagination import LimitOffsetPage
 from fastapi_pagination.ext.sqlalchemy import paginate
-from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 
-from pyfastapi.models.country import Country
-from pyfastapi.models.person import Person
+from pyfastapi.models import Person, Country
 from .base import BaseRepository
 
 
 class PersonRepository(BaseRepository):
     def get_person(self, id_: int) -> Person | None:
-        return (self.db.execute(select(Person)
-                .options(joinedload(Person.country).joinedload(Country.continent))
-                .where(Person.id == id_)).scalar_one_or_none())
+        stmt = select(Person, Country).join(Country, Person.country_code == Country.code).where(Person.id == id_)
+        return self.db.execute(stmt).scalar_one_or_none()
 
     def get_persons(self) -> LimitOffsetPage[Person]:
         person_list: LimitOffsetPage[Person] = paginate(self.db, select(Person))

--- a/pyfastapi/repositories/person.py
+++ b/pyfastapi/repositories/person.py
@@ -1,11 +1,11 @@
-from sqlalchemy.orm import joinedload
-from sqlalchemy.sql import select
 from fastapi_pagination import LimitOffsetPage
 from fastapi_pagination.ext.sqlalchemy import paginate
+from sqlalchemy.orm import joinedload
+from sqlalchemy.sql import select
 
-from .base import BaseRepository
-from pyfastapi.models.person import Person
 from pyfastapi.models.country import Country
+from pyfastapi.models.person import Person
+from .base import BaseRepository
 
 
 class PersonRepository(BaseRepository):

--- a/pyfastapi/repositories/person.py
+++ b/pyfastapi/repositories/person.py
@@ -1,5 +1,6 @@
 from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
+from fastapi_pagination import LimitOffsetPage
 from fastapi_pagination.ext.sqlalchemy import paginate
 
 from .base import BaseRepository
@@ -8,20 +9,21 @@ from pyfastapi.models.country import Country
 
 
 class PersonRepository(BaseRepository):
-    def get_person(self, id_: int):
+    def get_person(self, id_: int) -> Person | None:
         return (self.db.execute(select(Person)
                 .options(joinedload(Person.country).joinedload(Country.continent))
                 .where(Person.id == id_)).scalar_one_or_none())
 
-    def get_persons(self):
-        return paginate(self.db, select(Person))
+    def get_persons(self) -> LimitOffsetPage[Person]:
+        person_list: LimitOffsetPage[Person] = paginate(self.db, select(Person))
+        return person_list
 
-    def create_new_person(self, person: Person):
+    def create_new_person(self, person: Person) -> Person:
         self.db.add(person)
         self.db.commit()
         self.db.refresh(person)
         return person
 
-    def update_or_create_person(self, person: Person):
+    def update_or_create_person(self, person: Person) -> None:
         self.db.merge(person)
         self.db.commit()

--- a/pyfastapi/schemas/__init__.py
+++ b/pyfastapi/schemas/__init__.py
@@ -1,5 +1,7 @@
 from .continent import ContinentSchema
 from .country import CountrySchema, CountryListSchema
-from .person import PersonListSchema, PersonCreateSchema
+from .person import PersonListSchema, PersonCreateSchema, PersonSchema
 
-__all__ = ["ContinentSchema", "CountrySchema", "CountryListSchema", "PersonListSchema", "PersonCreateSchema"]
+__all__ = [
+    "ContinentSchema", "CountrySchema", "CountryListSchema", "PersonSchema", "PersonListSchema", "PersonCreateSchema"
+]

--- a/pyfastapi/schemas/continent.py
+++ b/pyfastapi/schemas/continent.py
@@ -1,4 +1,3 @@
-
 from pydantic import BaseModel
 
 

--- a/pyfastapi/schemas/country.py
+++ b/pyfastapi/schemas/country.py
@@ -1,4 +1,3 @@
-
 from pydantic import BaseModel
 
 from pyfastapi.schemas import ContinentSchema

--- a/pyfastapi/schemas/country.py
+++ b/pyfastapi/schemas/country.py
@@ -19,7 +19,7 @@ class CountryBaseSchema(BaseModel):
 
 
 class CountrySchema(CountryBaseSchema):
-    continents: ContinentSchema
+    continent: ContinentSchema
 
 
 class CountryListSchema(CountryBaseSchema):

--- a/pyfastapi/schemas/person.py
+++ b/pyfastapi/schemas/person.py
@@ -1,4 +1,3 @@
-
 from pydantic import BaseModel, Field
 
 from pyfastapi.schemas import CountrySchema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ pytest = "^8.0.0"
 flake8 = "^7.0.0"
 faker = "^22.6.0"
 coverage = "^7.4.1"
+mypy = "^1.8.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/api_tests/test_continents.py
+++ b/tests/api_tests/test_continents.py
@@ -9,7 +9,7 @@ from pyfastapi.models.continent import Continent
 client = TestClient(app)
 
 
-def test_countries_seed_data():
+def test_countries_seed_data() -> None:
     """
     if seed data is modified, this will fail
     """
@@ -18,14 +18,14 @@ def test_countries_seed_data():
     assert count == 7
 
 
-def test_get_continents():
+def test_get_continents() -> None:
     response = client.get("/continents")
     body = response.json()
     assert response.status_code == 200
     assert len(body) == 7
 
 
-def test_get_one_continent():
+def test_get_one_continent() -> None:
     continent = "AF"
     response = client.get(f"/continents/{continent}")
     body = response.json()
@@ -33,7 +33,7 @@ def test_get_one_continent():
     assert body["code"] == continent
 
 
-def test_get_one_continent_not_found():
+def test_get_one_continent_not_found() -> None:
     continent = "ZZ"
     response = client.get(f"/continents/{continent}")
     assert response.status_code == 404

--- a/tests/api_tests/test_continents.py
+++ b/tests/api_tests/test_continents.py
@@ -1,11 +1,10 @@
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from pyfastapi.main import app
 from pyfastapi.libs.db import get_db
+from pyfastapi.main import app
 from pyfastapi.models import Continent
 from pyfastapi.schemas import ContinentSchema
-
 
 client = TestClient(app)
 

--- a/tests/api_tests/test_continents.py
+++ b/tests/api_tests/test_continents.py
@@ -3,7 +3,8 @@ from sqlalchemy.orm import Session
 
 from pyfastapi.main import app
 from pyfastapi.libs.db import get_db
-from pyfastapi.models.continent import Continent
+from pyfastapi.models import Continent
+from pyfastapi.schemas import ContinentSchema
 
 
 client = TestClient(app)
@@ -28,9 +29,9 @@ def test_get_continents() -> None:
 def test_get_one_continent() -> None:
     continent = "AF"
     response = client.get(f"/continents/{continent}")
-    body = response.json()
+    body: ContinentSchema = ContinentSchema(**response.json())
     assert response.status_code == 200
-    assert body["code"] == continent
+    assert body.code == continent
 
 
 def test_get_one_continent_not_found() -> None:

--- a/tests/api_tests/test_continents.py
+++ b/tests/api_tests/test_continents.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import select, func
 
 from pyfastapi.libs.db import get_db
 from pyfastapi.main import app
@@ -14,7 +15,8 @@ def test_countries_seed_data() -> None:
     if seed data is modified, this will fail
     """
     db: Session = next(get_db())
-    count = db.query(Continent.code).count()
+    stmt = select(func.count()).select_from(Continent)
+    count = db.execute(stmt).scalar_one()
     assert count == 7
 
 

--- a/tests/api_tests/test_countries.py
+++ b/tests/api_tests/test_countries.py
@@ -34,7 +34,7 @@ def test_get_countries_limit_10() -> None:
     body: LimitOffsetPage[CountryListSchema]
     response, body = get_paginated("/countries", client, limit=limit)
     assert len(body.items) == int(limit)
-    country = body.items[0]
+    country: CountryListSchema = CountryListSchema.model_validate(body.items[0])
     assert country.code == FIRST_COUNTRY
 
 
@@ -44,7 +44,7 @@ def test_get_countries_limit_5_offset_10() -> None:
     body: LimitOffsetPage[CountryListSchema]
     response, body = get_paginated("/countries", client, limit=limit, offset=offset)
     assert len(body.items) == int(limit)
-    country = body.items[0]
+    country: CountryListSchema = CountryListSchema.model_validate(body.items[0])
     assert country.code != FIRST_COUNTRY
 
 

--- a/tests/api_tests/test_countries.py
+++ b/tests/api_tests/test_countries.py
@@ -1,9 +1,11 @@
 from fastapi.testclient import TestClient
+from fastapi_pagination import LimitOffsetPage
 from sqlalchemy.orm import Session
 
 from pyfastapi.main import app
 from pyfastapi.libs.db import get_db
-from pyfastapi.models.country import Country
+from pyfastapi.models import Country
+from pyfastapi.schemas import CountryListSchema
 from tests.api_tests.util_pagination_helper import get_paginated
 
 DEFAULT_LIMIT = 50
@@ -22,31 +24,36 @@ def test_countries_seed_data() -> None:
 
 
 def test_get_countries_default_limit() -> None:
+    body: LimitOffsetPage[CountryListSchema]
     response, body = get_paginated("/countries", client)
-    assert len(body['items']) == DEFAULT_LIMIT
+    assert len(body.items) == DEFAULT_LIMIT
 
 
 def test_get_countries_limit_10() -> None:
     limit = "10"
+    body: LimitOffsetPage[CountryListSchema]
     response, body = get_paginated("/countries", client, limit=limit)
-    assert len(body["items"]) == int(limit)
-    assert body["items"][0]["code"] == FIRST_COUNTRY
+    assert len(body.items) == int(limit)
+    country = body.items[0]
+    assert country.code == FIRST_COUNTRY
 
 
 def test_get_countries_limit_5_offset_10() -> None:
     limit = "5"
     offset = "10"
+    body: LimitOffsetPage[CountryListSchema]
     response, body = get_paginated("/countries", client, limit=limit, offset=offset)
-    assert len(body["items"]) == int(limit)
-    assert body["items"][0]["code"] != FIRST_COUNTRY
+    assert len(body.items) == int(limit)
+    country = body.items[0]
+    assert country.code != FIRST_COUNTRY
 
 
 def test_get_one_country() -> None:
     country = "HK"
     response = client.get(f"/countries/{country}")
-    body = response.json()
+    body: CountryListSchema = CountryListSchema(**response.json())
     assert response.status_code == 200
-    assert body["code"] == country
+    assert body.code == country
 
 
 def test_get_one_country_not_found() -> None:

--- a/tests/api_tests/test_countries.py
+++ b/tests/api_tests/test_countries.py
@@ -2,8 +2,8 @@ from fastapi.testclient import TestClient
 from fastapi_pagination import LimitOffsetPage
 from sqlalchemy.orm import Session
 
-from pyfastapi.main import app
 from pyfastapi.libs.db import get_db
+from pyfastapi.main import app
 from pyfastapi.models import Country
 from pyfastapi.schemas import CountryListSchema
 from tests.api_tests.util_pagination_helper import get_paginated

--- a/tests/api_tests/test_countries.py
+++ b/tests/api_tests/test_countries.py
@@ -12,7 +12,7 @@ FIRST_COUNTRY = "AF"
 client = TestClient(app)
 
 
-def test_countries_seed_data():
+def test_countries_seed_data() -> None:
     """
     if seed data is modified, this will fail
     """
@@ -21,19 +21,19 @@ def test_countries_seed_data():
     assert count == 252
 
 
-def test_get_countries_default_limit():
+def test_get_countries_default_limit() -> None:
     response, body = get_paginated("/countries", client)
     assert len(body['items']) == DEFAULT_LIMIT
 
 
-def test_get_countries_limit_10():
+def test_get_countries_limit_10() -> None:
     limit = "10"
     response, body = get_paginated("/countries", client, limit=limit)
     assert len(body["items"]) == int(limit)
     assert body["items"][0]["code"] == FIRST_COUNTRY
 
 
-def test_get_countries_limit_5_offset_10():
+def test_get_countries_limit_5_offset_10() -> None:
     limit = "5"
     offset = "10"
     response, body = get_paginated("/countries", client, limit=limit, offset=offset)
@@ -41,7 +41,7 @@ def test_get_countries_limit_5_offset_10():
     assert body["items"][0]["code"] != FIRST_COUNTRY
 
 
-def test_get_one_country():
+def test_get_one_country() -> None:
     country = "HK"
     response = client.get(f"/countries/{country}")
     body = response.json()
@@ -49,7 +49,7 @@ def test_get_one_country():
     assert body["code"] == country
 
 
-def test_get_one_country_not_found():
+def test_get_one_country_not_found() -> None:
     country = "ZZ"
     response = client.get(f"/countries/{country}")
     assert response.status_code == 404

--- a/tests/api_tests/test_countries.py
+++ b/tests/api_tests/test_countries.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 from fastapi_pagination import LimitOffsetPage
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import select, func
 
 from pyfastapi.libs.db import get_db
 from pyfastapi.main import app
@@ -19,7 +20,8 @@ def test_countries_seed_data() -> None:
     if seed data is modified, this will fail
     """
     db: Session = next(get_db())
-    count = db.query(Country.code).count()
+    stmt = select(func.count()).select_from(Country)
+    count = db.execute(stmt).scalar_one()
     assert count == 252
 
 

--- a/tests/api_tests/test_persons.py
+++ b/tests/api_tests/test_persons.py
@@ -1,19 +1,18 @@
-from typing import Sequence, List
+from typing import Sequence
 
+from faker import Faker
+from fastapi.testclient import TestClient
 from fastapi_pagination import LimitOffsetPage
 from pytest import fixture
-from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import select
-from faker import Faker
 
-from pyfastapi.main import app
 from pyfastapi.libs.db import get_db
-from pyfastapi.models import Person, Country
-from pyfastapi.schemas import PersonListSchema, CountryListSchema
+from pyfastapi.main import app
+from pyfastapi.models import Person
+from pyfastapi.schemas import PersonListSchema
 from pyfastapi.schemas.person import PersonSchema
 from tests.api_tests.util_pagination_helper import get_paginated
-
 
 DEFAULT_LIMIT = 50
 FIRST_PERSON = 1

--- a/tests/api_tests/test_persons.py
+++ b/tests/api_tests/test_persons.py
@@ -58,7 +58,7 @@ def test_persons_limit_10() -> None:
     body: LimitOffsetPage[PersonListSchema]
     response, body = get_paginated("/persons", client, limit=limit)
     assert len(body.items) == int(limit)
-    person: PersonListSchema = body.items[0]
+    person: PersonListSchema = PersonListSchema.model_validate(body.items[0])
     assert person.id == FIRST_PERSON
 
 
@@ -68,13 +68,14 @@ def test_persons_limit_5_offset_10(add_50_records: None) -> None:
     body: LimitOffsetPage[PersonListSchema]
     response, body = get_paginated("/persons", client, limit=limit, offset=offset)
     assert len(body.items) == int(limit)
-    person = body.items[0]
+    person: PersonListSchema = PersonListSchema.model_validate(body.items[0])
     assert person.id != FIRST_PERSON
 
 
 def test_get_one_person() -> None:
     person_id = 1
     response = client.get(f"/persons/{person_id}")
+    print("test_get_one_person", response.json())
     body: PersonSchema = PersonSchema(**response.json())
     country = body.country
     continent = country.continent

--- a/tests/api_tests/util_pagination_helper.py
+++ b/tests/api_tests/util_pagination_helper.py
@@ -2,7 +2,6 @@ from typing import Tuple, TypeVar
 
 from fastapi.testclient import TestClient
 from fastapi_pagination import LimitOffsetPage
-# from fastapi import Response
 from httpx import Response
 
 T = TypeVar("T")

--- a/tests/api_tests/util_pagination_helper.py
+++ b/tests/api_tests/util_pagination_helper.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Dict, Any, TypeVar, Iterable, cast
+from typing import Tuple, Dict, Any, TypeVar, Iterable, cast, Sequence
 
 from fastapi_pagination import LimitOffsetPage
 # from fastapi import Response
@@ -15,10 +15,7 @@ def get_paginated(path: str, client: TestClient, **kwargs: str) -> Tuple[Respons
         url=path,
         params=params
     )
-    body: LimitOffsetPage[T] = response.json()
-    # print("this is body", body)
+    body: LimitOffsetPage[T] = LimitOffsetPage(**response.json())
     assert response.status_code == 200
-    for k in ["items", "total", "limit", "offset"]:
-        assert body[k] is not None
-    # assert all(k in body for k in cast(Iterable[str], ["items", "total", "limit", "offset"]))
+    assert all(hasattr(body, k) for k in ["items", "total", "limit", "offset"])
     return response, body

--- a/tests/api_tests/util_pagination_helper.py
+++ b/tests/api_tests/util_pagination_helper.py
@@ -1,9 +1,9 @@
-from typing import Tuple, Dict, Any, TypeVar, Iterable, cast, Sequence
+from typing import Tuple, TypeVar
 
+from fastapi.testclient import TestClient
 from fastapi_pagination import LimitOffsetPage
 # from fastapi import Response
 from httpx import Response
-from fastapi.testclient import TestClient
 
 T = TypeVar("T")
 

--- a/tests/api_tests/util_pagination_helper.py
+++ b/tests/api_tests/util_pagination_helper.py
@@ -1,14 +1,24 @@
+from typing import Tuple, Dict, Any, TypeVar, Iterable, cast
+
+from fastapi_pagination import LimitOffsetPage
+# from fastapi import Response
+from httpx import Response
 from fastapi.testclient import TestClient
 
+T = TypeVar("T")
 
-def get_paginated(path: str, client: TestClient, **kwargs):
+
+def get_paginated(path: str, client: TestClient, **kwargs: str) -> Tuple[Response, LimitOffsetPage[T]]:
     params = {"limit": kwargs.get("limit"), "offset": kwargs.get("offset")}
     params = {k: v for k, v in params.items() if v}
-    response = client.get(
+    response: Response = client.get(
         url=path,
         params=params
     )
-    body = response.json()
+    body: LimitOffsetPage[T] = response.json()
+    # print("this is body", body)
     assert response.status_code == 200
-    assert all(k in body for k in ["items", "total", "limit", "offset"])
+    for k in ["items", "total", "limit", "offset"]:
+        assert body[k] is not None
+    # assert all(k in body for k in cast(Iterable[str], ["items", "total", "limit", "offset"]))
     return response, body

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,15 @@
+from typing import List, Iterator
 from pytest import fixture
 from alembic.config import Config
 from alembic import command
 from pyfastapi.config import get_config
 
 pytest_plugins = ["faker"]
-AppConfig = get_config(".env.test")
+AppConfig = get_config()
 
 
 @fixture(autouse=True)
-def init_db():
+def init_db() -> Iterator[None]:
     """
     this is equivalent to "alembic upgrade head" then run "alembic downgrade base" after 1 test is done
     runs every test to make sure we have a clean set of data
@@ -23,10 +24,10 @@ def init_db():
 
 # faker fixtures below
 @fixture(scope='session', autouse=True)
-def faker_session_locale():
+def faker_session_locale() -> List[str]:
     return ['en_US']
 
 
 @fixture(scope='session', autouse=True)
-def faker_seed():
+def faker_seed() -> int:
     return 12345

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 from typing import List, Iterator
-from pytest import fixture
-from alembic.config import Config
+
 from alembic import command
+from alembic.config import Config
+from pytest import fixture
+
 from pyfastapi.config import get_config
 
 pytest_plugins = ["faker"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,7 @@ from pyfastapi.main import app
 client = TestClient(app)
 
 
-def test_main_health():
+def test_main_health() -> None:
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## What?
add `mypy` to enforce static typing

## Why?
static typing makes it easier to maintain code

## How?
- add mypy and use `mypy --strict`
- fix all `mypy` issues

## Testing?
modfy some tests since it failed with the refactoring

## Anything Else?
- fix `get_config` since it cannot read `.env.test` when running pytest
- modify tests to use new `sqlalchemy` syntax