### PR TITLE
improve configuration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,5 @@
 ## Screenshots (optional)
 
 ## Anything Else?
+
+## AI Summary (optional)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Sample backend API built with **FastAPI**, **SQLAlchemy 2.x**, and **Alembic**. 
 
 5. Open `http://localhost:5000/docs` to view the OpenAPI docs
 
-## How to run in a container
+## How to run in a container (WIP)
 
 1. Build the image  
    `podman build -t pyfastapi .`
@@ -33,7 +33,7 @@ Sample backend API built with **FastAPI**, **SQLAlchemy 2.x**, and **Alembic**. 
    `podman run -p 5000:5000 pyfastapi`
 
 > Note: You can use `docker` instead of `podman` as it is a drop-in replacement.  
-> The Dockerfile currently references Poetry, but the active package manager is `uv`. See `architecture.md` for migration notes.
+> this part is still WIP.
 
 ## Seed Data
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,61 @@
 # PYFASTAPI
 
-sample backend using pyfastapi, sqlalchemy, and alembic
+Sample backend API built with **FastAPI**, **SQLAlchemy 2.x**, and **Alembic**. It demonstrates a layered architecture with CRUD endpoints for `Person`, `Country`, and `Continent`.
 
 ## Pre-requisites
-- python 3.12
-- poetry
-- sqlite
+
+- Python 3.12+
+- [uv](https://docs.astral.sh/uv/)
+- SQLite
 
 ## How to run
-1. install dependencies `poetry install`
-2. copy `.env.example` to `.env` and change the values if needed
-2. run the app `poetry run python run.py`
-3. call the api endpoint `curl http://localhost:5000/persons`
-4. open `http://localhost:5000/docs` to view then openapi docs
+
+1. Install dependencies  
+   `uv sync --locked --all-extras --dev`
+
+2. Copy `.env.example` to `.env` and change the values if needed  
+   `cp .env.example .env`
+
+3. Run the app  
+   `uv run python run.py`
+
+4. Call the API endpoint  
+   `curl http://localhost:5000/persons`
+
+5. Open `http://localhost:5000/docs` to view the OpenAPI docs
 
 ## How to run in a container
-1. build the image `podman build -t pyfastapi .`
-2. run the image `podman run -p 5000:5000 pyfastapi`
 
-note: you can use `docker` instead of `podman` as it is a drop in replacement
+1. Build the image  
+   `podman build -t pyfastapi .`
+
+2. Run the image  
+   `podman run -p 5000:5000 pyfastapi`
+
+> Note: You can use `docker` instead of `podman` as it is a drop-in replacement.  
+> The Dockerfile currently references Poetry, but the active package manager is `uv`. See `architecture.md` for migration notes.
 
 ## Seed Data
-1. run `alembic upgrade head`
-2. sql schema and the data should be on `./sql_app.db`
-3. refer to `alembic.ini` to change other configuration, it uses .env for the DB url
+
+1. Run migrations  
+   `alembic upgrade head`
+
+2. The SQL schema and seed data will be created in `./sql_app.db`
+
+3. Refer to `alembic.ini` to change other configuration. It uses `.env` for the DB URL.
 
 ## Tests
-1. make sure main dependencies are installed
-2. run `poetry install`
-2. run `pytest`, take note that it uses `.env.test` for configuration
+
+1. Make sure dependencies are installed  
+   `uv sync --locked --all-extras --dev`
+
+2. Run the test suite  
+   `uv run pytest`
+
+3. Run with coverage  
+   `uv run poe coverage`
+
+> Tests automatically set `ENVIRONMENT=test`, which loads `.env.test` for test configuration.
 
 ## Data Model
 
@@ -40,30 +67,26 @@ config:
 title: ERD
 ---
 erDiagram
-	person {
-		int id PK ""  
-		String last_name  ""  
-		String first_name  ""  
-		String country_code FK ""  
-		timestamp updated_at  ""  
-		timestamp created_at  ""  
-	}
-	country {
-		String code PK ""  
-		String name  ""  
-		int phone  ""  
-		String symbol  ""  
-		String capital  ""  
-		String currency  ""  
-		String continent_code FK ""  
-		String alpha_3  ""  
-		timestamp updated_at  ""  
-		timestamp created_at  ""  
-	}
-	continent {
-		String code PK ""  
-		String name  ""  
-	}
-	person}|--||country:"residesIn"
-	country}|--||continent:"belongsTo"
+    person {
+        int id PK
+        String last_name
+        String first_name
+        String country_code FK
+    }
+    country {
+        String code PK
+        String name
+        int phone
+        String symbol
+        String capital
+        String currency
+        String continent_code FK
+        String alpha_3
+    }
+    continent {
+        String code PK
+        String name
+    }
+    person }|--|| country : "residesIn"
+    country }|--|| continent : "belongsTo"
 ```

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -6,12 +6,9 @@ from sqlalchemy import pool
 
 from pyfastapi.utils.config import get_config
 
-AppConfig = get_config()
-
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-config.set_main_option("sqlalchemy.url", AppConfig.DB_HOST)
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
@@ -19,7 +16,7 @@ if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
 # add your model's MetaData object here
-# for 'autogenerate' support
+# for autogenerate support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
 target_metadata = None
@@ -42,6 +39,8 @@ def run_migrations_offline() -> None:
     script output.
 
     """
+    app_config = get_config()
+    config.set_main_option("sqlalchemy.url", app_config.DB_HOST)
     url = config.get_main_option("sqlalchemy.url")
     context.configure(
         url=url,
@@ -61,6 +60,8 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
+    app_config = get_config()
+    config.set_main_option("sqlalchemy.url", app_config.DB_HOST)
     connectable = engine_from_config(
         config.get_section(config.config_ini_section, {}),
         prefix="sqlalchemy.",

--- a/pyfastapi/libs/db.py
+++ b/pyfastapi/libs/db.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import sessionmaker, Session
 from pyfastapi.utils.config import get_config
 
 _engine: Engine | None = None
+_session_factory: sessionmaker[Session] | None = None
 
 
 def get_engine() -> Engine:
@@ -19,7 +20,10 @@ def get_engine() -> Engine:
 
 
 def get_session_factory() -> sessionmaker[Session]:
-    return sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
+    global _session_factory
+    if _session_factory is None:
+        _session_factory = sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
+    return _session_factory
 
 
 def get_db() -> Iterator[Session]:

--- a/pyfastapi/libs/db.py
+++ b/pyfastapi/libs/db.py
@@ -1,20 +1,29 @@
 from typing import Iterator
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, Engine
 from sqlalchemy.orm import sessionmaker, Session
 
 from pyfastapi.utils.config import get_config
 
-SQLALCHEMY_DATABASE_URL = get_config().DB_HOST
+_engine: Engine | None = None
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+def get_engine() -> Engine:
+    global _engine
+    if _engine is None:
+        _engine = create_engine(
+            get_config().DB_HOST,
+            connect_args={"check_same_thread": False},
+        )
+    return _engine
+
+
+def get_session_factory() -> sessionmaker[Session]:
+    return sessionmaker(autocommit=False, autoflush=False, bind=get_engine())
 
 
 def get_db() -> Iterator[Session]:
-    db = SessionLocal()
+    db = get_session_factory()()
     try:
         yield db
     finally:

--- a/pyfastapi/utils/config.py
+++ b/pyfastapi/utils/config.py
@@ -1,4 +1,4 @@
-import sys
+import os
 from functools import lru_cache
 from logging import getLogger
 
@@ -8,14 +8,14 @@ logger = getLogger(__name__)
 
 
 class Settings(BaseSettings):
-
     def __init__(self, _env_file: str) -> None:
         super().__init__(_env_file=_env_file)
 
     DB_HOST: str = "sqlite:///./sql_app.db"
     HOST: str = "0.0.0.0"
-    PORT: int = 5000
+    PORT: int = 3000
     LOG_LEVEL: str = "info"
+    ENVIRONMENT: str = "development"
 
     model_config = SettingsConfigDict()
 
@@ -23,13 +23,12 @@ class Settings(BaseSettings):
 @lru_cache
 def get_config() -> Settings:
     """
-    Get the configuration settings
-    This will check if it is running on pytest.
-    If it is, it will use the .env.test file, otherwise it will use the .env file
+    Get the configuration settings.
+    Uses the ENVIRONMENT env var to decide which env file to load.
     """
-    file = ".env.test" if "pytest" in sys.modules else ".env"
-    logger.info(f"logger input file {file}")
-    return Settings(_env_file=file)
+    env_file = ".env.test" if os.getenv("ENVIRONMENT") == "test" else ".env"
+    logger.info(f"loading env file {env_file}")
+    return Settings(_env_file=env_file)
 
 
 __all__ = ["get_config"]

--- a/pyfastapi/utils/config.py
+++ b/pyfastapi/utils/config.py
@@ -13,7 +13,7 @@ class Settings(BaseSettings):
 
     DB_HOST: str = "sqlite:///./sql_app.db"
     HOST: str = "0.0.0.0"
-    PORT: int = 3000
+    PORT: int = 5000
     LOG_LEVEL: str = "info"
     ENVIRONMENT: str = "development"
 

--- a/run.py
+++ b/run.py
@@ -5,7 +5,6 @@ from pyfastapi.utils.config import get_config
 from pyfastapi.utils import configure_log
 from pyfastapi import app
 
-Config = get_config()
-
 if __name__ == "__main__":
-    uvicorn.run(app, host=Config.HOST, port=Config.PORT, log_config=configure_log(LOGGING_CONFIG))
+    config = get_config()
+    uvicorn.run(app, host=config.HOST, port=config.PORT, log_config=configure_log(LOGGING_CONFIG))

--- a/tests/api_tests/test_continents.py
+++ b/tests/api_tests/test_continents.py
@@ -2,32 +2,27 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import select, func
 
-from pyfastapi.libs.db import get_db
-from pyfastapi.main import app
 from pyfastapi.models import Continent
 from pyfastapi.schemas import ContinentSchema
 
-client = TestClient(app)
 
-
-def test_countries_seed_data(init_db: None) -> None:
+def test_countries_seed_data(init_db: None, db_session: Session) -> None:
     """
     if seed data is modified, this will fail
     """
-    db: Session = next(get_db())
     stmt = select(func.count()).select_from(Continent)
-    count = db.execute(stmt).scalar_one()
+    count = db_session.execute(stmt).scalar_one()
     assert count == 7
 
 
-def test_get_continents(init_db: None) -> None:
+def test_get_continents(init_db: None, client: TestClient) -> None:
     response = client.get("/continents")
     body = response.json()
     assert response.status_code == 200
     assert len(body) == 7
 
 
-def test_get_one_continent(init_db: None) -> None:
+def test_get_one_continent(init_db: None, client: TestClient) -> None:
     continent = "AF"
     response = client.get(f"/continents/{continent}")
     body: ContinentSchema = ContinentSchema(**response.json())
@@ -35,7 +30,7 @@ def test_get_one_continent(init_db: None) -> None:
     assert body.code == continent
 
 
-def test_get_one_continent_not_found(init_db: None) -> None:
+def test_get_one_continent_not_found(init_db: None, client: TestClient) -> None:
     continent = "ZZ"
     response = client.get(f"/continents/{continent}")
     assert response.status_code == 404

--- a/tests/api_tests/test_countries.py
+++ b/tests/api_tests/test_countries.py
@@ -3,8 +3,6 @@ from fastapi_pagination import LimitOffsetPage
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import select, func
 
-from pyfastapi.libs.db import get_db
-from pyfastapi.main import app
 from pyfastapi.models import Country
 from pyfastapi.schemas import CountryListSchema
 from tests.api_tests.util_pagination_helper import get_paginated
@@ -12,26 +10,23 @@ from tests.api_tests.util_pagination_helper import get_paginated
 DEFAULT_LIMIT = 50
 FIRST_COUNTRY = "AF"
 
-client = TestClient(app)
 
-
-def test_countries_seed_data(init_db: None) -> None:
+def test_countries_seed_data(init_db: None, db_session: Session) -> None:
     """
     if seed data is modified, this will fail
     """
-    db: Session = next(get_db())
     stmt = select(func.count()).select_from(Country)
-    count = db.execute(stmt).scalar_one()
+    count = db_session.execute(stmt).scalar_one()
     assert count == 252
 
 
-def test_get_countries_default_limit(init_db: None) -> None:
+def test_get_countries_default_limit(init_db: None, client: TestClient) -> None:
     body: LimitOffsetPage[CountryListSchema]
     response, body = get_paginated("/countries", client)
     assert len(body.items) == DEFAULT_LIMIT
 
 
-def test_get_countries_limit_10(init_db: None) -> None:
+def test_get_countries_limit_10(init_db: None, client: TestClient) -> None:
     limit = "10"
     body: LimitOffsetPage[CountryListSchema]
     response, body = get_paginated("/countries", client, limit=limit)
@@ -40,7 +35,7 @@ def test_get_countries_limit_10(init_db: None) -> None:
     assert country.code == FIRST_COUNTRY
 
 
-def test_get_countries_limit_5_offset_10(init_db: None) -> None:
+def test_get_countries_limit_5_offset_10(init_db: None, client: TestClient) -> None:
     limit = "5"
     offset = "10"
     body: LimitOffsetPage[CountryListSchema]
@@ -50,7 +45,7 @@ def test_get_countries_limit_5_offset_10(init_db: None) -> None:
     assert country.code != FIRST_COUNTRY
 
 
-def test_get_countries_with_filter(init_db: None) -> None:
+def test_get_countries_with_filter(init_db: None, client: TestClient) -> None:
     filter_ = "name=Hong Kong"
     body: LimitOffsetPage[CountryListSchema]
     response, body = get_paginated(f"/countries?{filter_}", client)
@@ -59,7 +54,7 @@ def test_get_countries_with_filter(init_db: None) -> None:
     assert country.name == "Hong Kong"
 
 
-def test_get_countries_with_sort_asc(init_db: None) -> None:
+def test_get_countries_with_sort_asc(init_db: None, client: TestClient) -> None:
     sort = "name"
     body: LimitOffsetPage[CountryListSchema]
     response, body = get_paginated(f"/countries?sort={sort}", client)
@@ -68,7 +63,7 @@ def test_get_countries_with_sort_asc(init_db: None) -> None:
     assert country.name == "Afghanistan"
 
 
-def test_get_countries_with_sort_desc(init_db: None) -> None:
+def test_get_countries_with_sort_desc(init_db: None, client: TestClient) -> None:
     sort = "-name"
     body: LimitOffsetPage[CountryListSchema]
     response, body = get_paginated(f"/countries?sort={sort}", client)
@@ -77,7 +72,7 @@ def test_get_countries_with_sort_desc(init_db: None) -> None:
     assert country.name == "Zimbabwe"
 
 
-def test_get_one_country(init_db: None) -> None:
+def test_get_one_country(init_db: None, client: TestClient) -> None:
     country = "HK"
     response = client.get(f"/countries/{country}")
     body: CountryListSchema = CountryListSchema(**response.json())
@@ -85,7 +80,7 @@ def test_get_one_country(init_db: None) -> None:
     assert body.code == country
 
 
-def test_get_one_country_not_found(init_db: None) -> None:
+def test_get_one_country_not_found(init_db: None, client: TestClient) -> None:
     country = "ZZ"
     response = client.get(f"/countries/{country}")
     assert response.status_code == 404

--- a/tests/api_tests/test_persons.py
+++ b/tests/api_tests/test_persons.py
@@ -7,8 +7,6 @@ from pytest import fixture
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import select, func
 
-from pyfastapi.libs.db import get_db
-from pyfastapi.main import app
 from pyfastapi.models import Person
 from pyfastapi.schemas import PersonListSchema, PersonSchema, CountrySchema
 from tests.api_tests.util_pagination_helper import get_paginated
@@ -17,12 +15,9 @@ DEFAULT_LIMIT = 50
 FIRST_PERSON = 1
 NUM_SEED_DATA = 13
 
-client = TestClient(app)
-
 
 @fixture(scope="function")
-def add_50_records(faker: Faker) -> None:
-    db: Session = next(get_db())
+def add_50_records(faker: Faker, db_session: Session) -> None:
     person_list = []
     for i in range(50):
         name = faker.name().split()
@@ -32,33 +27,31 @@ def add_50_records(faker: Faker) -> None:
             country_code="HK"
         )
         person_list.append(person)
-    db.bulk_save_objects(person_list)
-    db.commit()
+    db_session.bulk_save_objects(person_list)
+    db_session.commit()
 
 
 @fixture(scope="function")
-def add_juan_dela_cruz() -> None:
-    db: Session = next(get_db())
+def add_juan_dela_cruz(db_session: Session) -> None:
     person = Person(
         first_name="Juan",
         last_name="dela Cruz",
         country_code="PH"
     )
-    db.add(person)
-    db.commit()
+    db_session.add(person)
+    db_session.commit()
 
 
-def test_persons_seed_data(init_db: None) -> None:
+def test_persons_seed_data(init_db: None, db_session: Session) -> None:
     """
     if seed data is modified, this will fail
     """
-    db: Session = next(get_db())
     stmt = select(func.count()).select_from(Person)
-    count = db.execute(stmt).scalar_one()
+    count = db_session.execute(stmt).scalar_one()
     assert count == NUM_SEED_DATA
 
 
-def test_persons_default_pagination(init_db: None, add_50_records: None) -> None:
+def test_persons_default_pagination(init_db: None, add_50_records: None, client: TestClient) -> None:
     body: LimitOffsetPage[Person]
     response, body = get_paginated("/persons", client)
     items: Sequence[Person] = body.items
@@ -66,7 +59,7 @@ def test_persons_default_pagination(init_db: None, add_50_records: None) -> None
     assert body_length == DEFAULT_LIMIT
 
 
-def test_persons_limit_10(init_db: None) -> None:
+def test_persons_limit_10(init_db: None, client: TestClient) -> None:
     limit = "10"
     body: LimitOffsetPage[PersonListSchema]
     response, body = get_paginated("/persons", client, limit=limit)
@@ -75,7 +68,7 @@ def test_persons_limit_10(init_db: None) -> None:
     assert person.id == FIRST_PERSON
 
 
-def test_persons_limit_5_offset_10(init_db: None, add_50_records: None) -> None:
+def test_persons_limit_5_offset_10(init_db: None, add_50_records: None, client: TestClient) -> None:
     limit = "5"
     offset = "10"
     body: LimitOffsetPage[PersonListSchema]
@@ -85,7 +78,7 @@ def test_persons_limit_5_offset_10(init_db: None, add_50_records: None) -> None:
     assert person.id != FIRST_PERSON
 
 
-def test_persons_with_filter(init_db: None, add_juan_dela_cruz: None) -> None:
+def test_persons_with_filter(init_db: None, add_juan_dela_cruz: None, client: TestClient) -> None:
     filter_ = "first_name=juan&last_name=cruz"
     body: LimitOffsetPage[PersonListSchema]
     response, body = get_paginated(f"/persons?{filter_}", client)
@@ -96,7 +89,7 @@ def test_persons_with_filter(init_db: None, add_juan_dela_cruz: None) -> None:
     assert person.country_code == "PH"
 
 
-def test_persons_with_sort_asc(init_db: None) -> None:
+def test_persons_with_sort_asc(init_db: None, client: TestClient) -> None:
     sort = "first_name"
     body: LimitOffsetPage[PersonListSchema]
     response, body = get_paginated(f"/persons?sort={sort}", client)
@@ -105,7 +98,7 @@ def test_persons_with_sort_asc(init_db: None) -> None:
     assert person.first_name == "Adam"
 
 
-def test_persons_with_sort_desc(init_db: None) -> None:
+def test_persons_with_sort_desc(init_db: None, client: TestClient) -> None:
     sort = "-first_name"
     body: LimitOffsetPage[PersonListSchema]
     response, body = get_paginated(f"/persons?sort={sort}", client)
@@ -114,7 +107,7 @@ def test_persons_with_sort_desc(init_db: None) -> None:
     assert person.first_name == "Zoe"
 
 
-def test_get_one_person(init_db: None) -> None:
+def test_get_one_person(init_db: None, client: TestClient) -> None:
     person_id = 1
     response = client.get(f"/persons/{person_id}")
     body: PersonSchema = PersonSchema(**response.json())
@@ -126,14 +119,14 @@ def test_get_one_person(init_db: None) -> None:
     assert all(hasattr(continent, k) for k in ["code", "name"])
 
 
-def test_get_one_person_not_found(init_db: None) -> None:
+def test_get_one_person_not_found(init_db: None, client: TestClient) -> None:
     person_id = 0
     response = client.get(f"/persons/{person_id}")
     assert response.status_code == 404
     assert response.json() == {"detail": f"Person {person_id} not found"}
 
 
-def test_create_person(init_db: None) -> None:
+def test_create_person(init_db: None, client: TestClient, db_session: Session) -> None:
     first_name = "test1"
     last_name = "test2"
     country_code = "PH"
@@ -150,13 +143,12 @@ def test_create_person(init_db: None) -> None:
     assert body.id is not None
 
     # should add 1 to total
-    db: Session = next(get_db())
     stmt = select(func.count()).select_from(Person)
-    count: int = db.execute(stmt).scalar_one()
+    count: int = db_session.execute(stmt).scalar_one()
     assert count == 14
 
 
-def test_update_person(init_db: None) -> None:
+def test_update_person(init_db: None, client: TestClient, db_session: Session) -> None:
     first_name = "test1"
     last_name = "test2"
     country_code = "PH"
@@ -176,9 +168,8 @@ def test_update_person(init_db: None) -> None:
     response2 = client.put(f"/persons/{id_}", json=data)
     assert response2.status_code == 204
 
-    db: Session = next(get_db())
     stmt = select(Person).where(Person.id == id_)
-    updated_person: Person = db.execute(stmt).scalar_one()
+    updated_person: Person = db_session.execute(stmt).scalar_one()
     assert updated_person.first_name == first_name
     assert updated_person.last_name == last_name
     assert updated_person.country_code == country_code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,12 @@ from typing import Iterator
 
 from alembic import command
 from alembic.config import Config
+from fastapi.testclient import TestClient
 from pytest import fixture
+from sqlalchemy.orm import Session
 
+from pyfastapi.libs.db import get_session_factory
+from pyfastapi.main import app
 from pyfastapi.utils.config import get_config
 
 os.environ.setdefault("ENVIRONMENT", "test")
@@ -25,6 +29,22 @@ def init_db() -> Iterator[None]:
     command.upgrade(config, "head")
     yield None
     command.downgrade(config, "base")
+
+
+@fixture(scope="session")
+def client() -> Iterator[TestClient]:
+    with TestClient(app) as c:
+        yield c
+
+
+@fixture(scope="function")
+def db_session() -> Iterator[Session]:
+    factory = get_session_factory()
+    db = factory()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 # faker fixtures below

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ from pyfastapi.libs.db import get_session_factory
 from pyfastapi.main import app
 from pyfastapi.utils.config import get_config
 
-os.environ.setdefault("ENVIRONMENT", "test")
+os.environ["ENVIRONMENT"] = "test"
 
 pytest_plugins = ["faker"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-from typing import List, Iterator
+import os
+from typing import Iterator
 
 from alembic import command
 from alembic.config import Config
@@ -6,8 +7,9 @@ from pytest import fixture
 
 from pyfastapi.utils.config import get_config
 
+os.environ.setdefault("ENVIRONMENT", "test")
+
 pytest_plugins = ["faker"]
-AppConfig = get_config()
 
 
 @fixture(scope="function")
@@ -16,8 +18,9 @@ def init_db() -> Iterator[None]:
     this is equivalent to "alembic upgrade head" then run "alembic downgrade base" after 1 test is done
     runs every test to make sure we have a clean set of data
     """
+    app_config = get_config()
     config = Config()
-    config.set_main_option("sqlalchemy.url", AppConfig.DB_HOST)
+    config.set_main_option("sqlalchemy.url", app_config.DB_HOST)
     config.set_main_option("script_location", "alembic")
     command.upgrade(config, "head")
     yield None
@@ -26,7 +29,7 @@ def init_db() -> Iterator[None]:
 
 # faker fixtures below
 @fixture(scope="session", autouse=True)
-def faker_session_locale() -> List[str]:
+def faker_session_locale() -> list[str]:
     return ["en_US"]
 
 


### PR DESCRIPTION
## What?
- configuration fragility: load configuration explicitly rather than when a module is loaded, this also affects `TestClient`
- session leakage during test: not closing the session after obtaining it

## Why?
AI pointed out that the configuration is loaded on first call and this locks the configuration which makes changing configuration during testing more hacky

## How?
- explicitly initialize the configuration rather than getting it on first load
- close the db session after every test
- inject `TestClient` using the test runner

## AI Summary
This pull request introduces several improvements to the project’s configuration, database handling, documentation, and test suite. The main focus is on enhancing environment configuration flexibility, improving database session management, updating documentation for clarity and accuracy, and refactoring tests for better isolation and maintainability.

**Configuration and Environment Handling:**

* Refactored `get_config()` in `pyfastapi/utils/config.py` to select the environment file (`.env` or `.env.test`) based on the `ENVIRONMENT` environment variable instead of checking for pytest modules. Also, added a new `ENVIRONMENT` setting and changed the default port to `3000`. [[1]](diffhunk://#diff-6f7d2727792c644b1174385095cc3ed613425cb6a4ec4e54b3beaa9ef3d39c1eL1-R1) [[2]](diffhunk://#diff-6f7d2727792c644b1174385095cc3ed613425cb6a4ec4e54b3beaa9ef3d39c1eL11-R31)

**Database Session Handling:**

* Refactored `pyfastapi/libs/db.py` to use a singleton pattern for the SQLAlchemy engine and provide a `get_session_factory()` function, ensuring consistent and testable database session management.

**Documentation Updates:**

* Updated `README.md` to reflect the new dependency manager (`uv`), improved instructions for running and testing the app, clarified container usage, and revised the ERD to remove unnecessary field descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R58) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R88)

**Alembic Migration Configuration:**

* Changed Alembic’s `env.py` to set the database URL dynamically using the current environment, ensuring migrations use the correct configuration based on the active environment. [[1]](diffhunk://#diff-cd4d26a53ff97e019b612811dfa604ba24d5dfd2f4dc1b195f3e74d85c38e630L9-R19) [[2]](diffhunk://#diff-cd4d26a53ff97e019b612811dfa604ba24d5dfd2f4dc1b195f3e74d85c38e630R42-R43) [[3]](diffhunk://#diff-cd4d26a53ff97e019b612811dfa604ba24d5dfd2f4dc1b195f3e74d85c38e630R63-R64)

**Test Suite Refactoring:**

* Refactored all test files to use dependency-injected `db_session` and `client` fixtures instead of importing the app or direct DB access. This improves test isolation and reliability. [[1]](diffhunk://#diff-8a5b39d5d8c6f4d8e09f04d05a7453616401c3fb544f2b83e765cf2d07627ee1L5-R33) [[2]](diffhunk://#diff-e8df426709a57a59371ba5237ce03386ec95ba1b171f1c134052e8b6eeb22d85L6-R29) [[3]](diffhunk://#diff-e8df426709a57a59371ba5237ce03386ec95ba1b171f1c134052e8b6eeb22d85L43-R38) [[4]](diffhunk://#diff-e8df426709a57a59371ba5237ce03386ec95ba1b171f1c134052e8b6eeb22d85L53-R48) [[5]](diffhunk://#diff-e8df426709a57a59371ba5237ce03386ec95ba1b171f1c134052e8b6eeb22d85L62-R57) [[6]](diffhunk://#diff-e8df426709a57a59371ba5237ce03386ec95ba1b171f1c134052e8b6eeb22d85L71-R66) [[7]](diffhunk://#diff-e8df426709a57a59371ba5237ce03386ec95ba1b171f1c134052e8b6eeb22d85L80-R83) [[8]](diffhunk://#diff-ddf39cfe9664003ac5eee6c43269847d7d7592e00ee9d73a43075efe2618f560L10-L11) [[9]](diffhunk://#diff-ddf39cfe9664003ac5eee6c43269847d7d7592e00ee9d73a43075efe2618f560L20-R20) [[10]](diffhunk://#diff-ddf39cfe9664003ac5eee6c43269847d7d7592e00ee9d73a43075efe2618f560L35-R62) [[11]](diffhunk://#diff-ddf39cfe9664003ac5eee6c43269847d7d7592e00ee9d73a43075efe2618f560L88-R81) [[12]](diffhunk://#diff-ddf39cfe9664003ac5eee6c43269847d7d7592e00ee9d73a43075efe2618f560L99-R92) [[13]](diffhunk://#diff-ddf39cfe9664003ac5eee6c43269847d7d7592e00ee9d73a43075efe2618f560L108-R101) [[14]](diffhunk://#diff-ddf39cfe9664003ac5eee6c43269847d7d7592e00ee9d73a43075efe2618f560L117-R110) [[15]](diffhunk://#diff-ddf39cfe9664003ac5eee6c43269847d7d7592e00ee9d73a43075efe2618f560L129-R129)

These changes collectively improve the maintainability, clarity, and testability of the codebase.