### PR TITLE
modify to use upsert and alchemy style join

### DIFF
--- a/pyfastapi/repositories/person.py
+++ b/pyfastapi/repositories/person.py
@@ -1,16 +1,18 @@
 from toolz .functoolz import compose  # type: ignore
 from fastapi_pagination import LimitOffsetPage
 from fastapi_pagination.ext.sqlalchemy import paginate
+from sqlalchemy.dialects.sqlite import insert
+from sqlalchemy.orm import joinedload
 from sqlalchemy.sql import select
 
-from pyfastapi.models import Person, Country
+from pyfastapi.models import Person
 from pyfastapi.schemas import QueryPersonSchema, SortPersonEnum
 from .base import BaseRepository, extract_sort, extract_query
 
 
 class PersonRepository(BaseRepository):
     def get_person(self, id_: int) -> Person | None:
-        stmt = select(Person, Country).join(Country, Person.country_code == Country.code).where(Person.id == id_)
+        stmt = select(Person).options(joinedload(Person.country)).where(Person.id == id_)
         return self.db.execute(stmt).scalar_one_or_none()
 
     def get_persons(self, q: QueryPersonSchema, sort: str) -> LimitOffsetPage[Person]:
@@ -29,5 +31,19 @@ class PersonRepository(BaseRepository):
         return person
 
     def update_or_create_person(self, person: Person) -> None:
-        self.db.merge(person)
+        stmt = insert(Person).values(
+            id=person.id,
+            first_name=person.first_name,
+            last_name=person.last_name,
+            country_code=person.country_code
+        )
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[Person.id],
+            set_={
+                "first_name": stmt.excluded.first_name,
+                "last_name": stmt.excluded.last_name,
+                "country_code": stmt.excluded.country_code,
+            }
+        )
+        self.db.execute(stmt)
         self.db.commit()

--- a/tests/api_tests/test_persons.py
+++ b/tests/api_tests/test_persons.py
@@ -193,3 +193,61 @@ def test_update_person(init_db: None, client: TestClient, db_session: Session) -
     assert updated_person.first_name == first_name
     assert updated_person.last_name == last_name
     assert updated_person.country_code == country_code
+
+
+def test_upsert_create(init_db: None, client: TestClient, db_session: Session) -> None:
+    # Use an ID that doesn't exist in seed data (seed data has 13 persons, IDs likely 1-13)
+    new_id = 999
+    first_name = "Upsert"
+    last_name = "Create"
+    country_code = "US"
+    data = {
+        "first_name": first_name,
+        "last_name": last_name,
+        "country_code": country_code,
+    }
+
+    # Verify it doesn't exist
+    stmt_check = select(Person).where(Person.id == new_id)
+    assert db_session.execute(stmt_check).scalar_one_or_none() is None
+
+    # Perform PUT (UPSERT)
+    response = client.put(f"/persons/{new_id}", json=data)
+    assert response.status_code == 204
+
+    # Verify it was created
+    person_from_db = db_session.execute(stmt_check).scalar_one()
+    assert person_from_db.id == new_id
+    assert person_from_db.first_name == first_name
+    assert person_from_db.last_name == last_name
+    assert person_from_db.country_code == country_code
+
+
+def test_upsert_update(init_db: None, client: TestClient, db_session: Session) -> None:
+    # Use an existing ID from seed data
+    existing_id = 1
+    first_name = "Upsert"
+    last_name = "Update"
+    country_code = "GB"
+    data = {
+        "first_name": first_name,
+        "last_name": last_name,
+        "country_code": country_code,
+    }
+
+    # Verify it exists and is different
+    stmt_check = select(Person).where(Person.id == existing_id)
+    person_before = db_session.execute(stmt_check).scalar_one()
+    assert person_before.first_name != first_name
+
+    # Perform PUT (UPSERT)
+    response = client.put(f"/persons/{existing_id}", json=data)
+    assert response.status_code == 204
+
+    # Verify it was updated
+    db_session.expire_all()  # Ensure we get fresh data
+    person_after = db_session.execute(stmt_check).scalar_one()
+    assert person_after.id == existing_id
+    assert person_after.first_name == first_name
+    assert person_after.last_name == last_name
+    assert person_after.country_code == country_code


### PR DESCRIPTION
## What?
Modify persisting and loading data for persons

## Why?
on loading data: this ensures consistent eager loading and prevents potential N+1 lazy-load issues during serialization
on persisting: upsert would make the insert or update operation atomic

## How?
code change

## Testing?
add integration tests to cover upsert

## AI Summary (optional)
This pull request updates the `PersonRepository` to use an upsert (update-or-insert) approach for saving `Person` records and adds corresponding tests to ensure correct behavior. The main changes are the introduction of a database-level upsert using SQLite's `ON CONFLICT DO UPDATE` and the addition of tests to verify both creation and update via upsert.

**Repository improvements:**

* Changed the `update_or_create_person` method in `PersonRepository` to use a SQLite `insert` statement with `on_conflict_do_update`, enabling true upsert behavior instead of relying on SQLAlchemy's `merge` method. This ensures that if a `Person` with the given ID exists, it is updated; otherwise, a new record is created.
* Updated the `get_person` method to use `joinedload` for eager loading of the related `country`, improving query efficiency and code clarity.

**Testing improvements:**

* Added `test_upsert_create` to verify that a PUT request for a non-existent `Person` ID creates a new record as expected.
* Added `test_upsert_update` to verify that a PUT request for an existing `Person` ID updates the record correctly.