### PR TITLE
replace poetry with uv in docker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,7 @@ A `Dockerfile` is provided with a single-stage build:
 - **Base image**: `python:3.12.12-slim-bookworm`
 - **Package manager**: `uv` (installed via pip)
 - **Dependencies**: installed with `uv sync --frozen --no-dev`
-- **Entrypoint**: `alembic upgrade head && uv run --no-sync python -m run`
+- **Entrypoint**: `uv run --no-sync alembic upgrade head && uv run --no-sync python -m run`
 
 ## Security Considerations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ uv run python run.py
 
 The API will be available at `http://localhost:5000`. OpenAPI docs are at `/docs`.
 
-> **Note**: The `README.md` and `Dockerfile` reference `poetry`, but the active package manager in CI and the presence of `uv.lock` indicate `uv` is the current standard. The Dockerfile also references `poetry.lock`, which does not exist in the repo.
+> **Note**: The `README.md` and `Dockerfile` use `uv`. The `uv.lock` lockfile is the source of truth for dependencies.
 
 ### Environment Files
 
@@ -253,14 +253,12 @@ GitHub Actions workflow (`.github/workflows/python-app.yml`):
 
 ## Deployment
 
-A `Dockerfile` is provided with a multi-stage build:
+A `Dockerfile` is provided with a single-stage build:
 
-1. **Builder stage** (`python:3.12.1-bookworm`): Installs Poetry and project dependencies.
-2. **Runtime stage** (`python:3.12.1-slim-bookworm`): Copies the virtual environment and source code.
-
-**Entrypoint**: `alembic upgrade head && python -m run`
-
-> **Note**: The Dockerfile currently uses Poetry for installation and references `poetry.lock`, but the repo only contains `uv.lock`. If switching fully to `uv`, the Dockerfile should be updated accordingly.
+- **Base image**: `python:3.12.12-slim-bookworm`
+- **Package manager**: `uv` (installed via pip)
+- **Dependencies**: installed with `uv sync --frozen --no-dev`
+- **Entrypoint**: `alembic upgrade head && uv run --no-sync python -m run`
 
 ## Security Considerations
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,22 @@
-FROM python:3.12.1-bookworm as builder
+FROM python:3.12.12-slim-bookworm
 
 ENV PYTHONFAULTHANDLER=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONHASHSEED=random \
-    PYTHONDONTWRITEBYTECODE=1 \
-    # pip:
-    PIP_NO_CACHE_DIR=off \
-    PIP_DISABLE_PIP_VERSION_CHECK=on \
-    PIP_DEFAULT_TIMEOUT=100 \
-    # poetry:
-    POETRY_VERSION=1.7.1 \
-    POETRY_NO_INTERACTION=1 \
-    POETRY_VIRTUALENVS_IN_PROJECT=1 \
-    POETRY_VIRTUALENVS_CREATE=1 \
-    PATH="$PATH:/root/.local/bin"
+    PYTHONDONTWRITEBYTECODE=1
+
+# Install uv
+RUN pip install --no-cache-dir uv
 
 WORKDIR /app
 
-# install poetry
-RUN pip install pipx
-RUN pipx install "poetry==$POETRY_VERSION"
-RUN pipx ensurepath
+# Copy dependency manifests first for layer caching
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev --no-install-project
 
-# install dependencies
-COPY pyproject.toml poetry.lock ./
-RUN poetry install --without dev --no-root --no-ansi
-
-# next stage
-FROM python:3.12.1-slim-bookworm as runtime
-
-ENV VIRTUAL_ENV=/app/.venv \
-    PATH="/app/.venv/bin:$PATH"
-
-COPY --from=builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
-
+# Copy source and install the project itself
 COPY . .
+RUN uv sync --frozen --no-dev
 
-# for demo purposes, always run migrations then start the app
-ENTRYPOINT ["/bin/sh", "-c" , "alembic upgrade head && python -m run"]
+# For demo purposes, always run migrations then start the app
+ENTRYPOINT ["/bin/sh", "-c", "uv run --no-sync alembic upgrade head && uv run --no-sync python -m run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,18 @@ ENV PYTHONFAULTHANDLER=1 \
     PYTHONHASHSEED=random \
     PYTHONDONTWRITEBYTECODE=1
 
-# Install uv
-RUN pip install --no-cache-dir uv
+# Install uv (pinned to match CI version)
+RUN pip install --no-cache-dir uv==0.9.18
 
 WORKDIR /app
 
 # Copy dependency manifests first for layer caching
 COPY pyproject.toml uv.lock ./
-RUN uv sync --frozen --no-dev --no-install-project
+RUN uv sync --locked --no-dev --no-install-project
 
 # Copy source and install the project itself
 COPY . .
-RUN uv sync --frozen --no-dev
+RUN uv sync --locked --no-dev
 
 # For demo purposes, always run migrations then start the app
 ENTRYPOINT ["/bin/sh", "-c", "uv run --no-sync alembic upgrade head && uv run --no-sync python -m run"]

--- a/README.md
+++ b/README.md
@@ -24,16 +24,15 @@ Sample backend API built with **FastAPI**, **SQLAlchemy 2.x**, and **Alembic**. 
 
 5. Open `http://localhost:5000/docs` to view the OpenAPI docs
 
-## How to run in a container (WIP)
+## How to run in a container
 
 1. Build the image  
-   `podman build -t pyfastapi .`
+   `docker build -t pyfastapi .`
 
 2. Run the image  
-   `podman run -p 5000:5000 pyfastapi`
+   `docker run -p 5000:5000 pyfastapi`
 
-> Note: You can use `docker` instead of `podman` as it is a drop-in replacement.  
-> this part is still WIP.
+> Note: You can use `podman` instead of `docker` as it is a drop-in replacement.
 
 ## Seed Data
 


### PR DESCRIPTION
## What?

Switches the `Dockerfile` from **Poetry** to **uv**, aligning the container build with the project's current package manager (`uv.lock` is the source of truth; `poetry.lock` does not exist). Also updates related documentation (`README.md`, `AGENTS.md`, `architecture.md`) to reflect the new build process.

Key changes:
- **Dockerfile**: Replaced the multi-stage Poetry build with a single-stage `uv` build.
- **README.md**: Removed the "WIP" label from the container section and updated commands to use `docker` by default.
- **AGENTS.md**: Updated the Deployment section and removed the outdated note about Poetry references.
- **architecture.md**: Marked the P3 task "Dockerfile: switch from Poetry to `uv`" as completed.

## Why?

- The previous `Dockerfile` referenced `poetry.lock`, which **does not exist** in the repository. The project has already migrated to `uv` (CI uses `uv sync`, `uv.lock` is present).
- Keeping Poetry in the Dockerfile caused confusion for anyone trying to build the image and was flagged as a structural gap in `architecture.md`.
- Using `uv` in Docker gives us faster installs, better layer caching via `uv sync`, and a smaller, simpler image.

## How?

### Dockerfile changes
- **Base image**: Updated from `python:3.12.1-bookworm/slim-bookworm` to `python:3.12.12-slim-bookworm` (matching `.python-version`).
- **Simplified to single-stage**: Removed the separate builder/runtime stages since all dependencies are pure Python wheels and `uv` installs quickly.
- **Installs `uv`**: `RUN pip install --no-cache-dir uv`
- **Layer-cached dependency install**:
  1. Copy `pyproject.toml` + `uv.lock` → `uv sync --frozen --no-dev --no-install-project`
  2. Copy source code → `uv sync --frozen --no-dev`
- **Entrypoint**: Uses `uv run --no-sync` to ensure the virtualenv is activated correctly without re-verifying the lockfile at runtime:
  ```dockerfile
  ENTRYPOINT ["/bin/sh", "-c", "uv run --no-sync alembic upgrade head && uv run --no-sync python -m run"]
  ```

### Documentation updates
- `README.md`: Container instructions are no longer "WIP".
- `AGENTS.md`: Deployment section now describes the `uv`-based single-stage build.
- `architecture.md`: Removed the Dockerfile switch from the "next suggested steps" list.

## Testing?

- [x] `docker build -t pyfastapi-test .` completes successfully.
- [x] Container starts and runs migrations:
  ```
  INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
  INFO:     Started server process [15]
  INFO:     Application startup complete.
  INFO:     Uvicorn running on http://0.0.0.0:5000
  ```
- [x] Application responds to requests on port 5000 inside the container.

## Screenshots (optional)

N/A — infrastructure change only.

## Anything Else?

- We initially tried `COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv` to pull the `uv` binary directly, but the local Docker daemon returned an auth error from `ghcr.io`. Falling back to `pip install uv` inside the image is equally reliable and avoids registry issues.
- The single-stage tradeoff: if a future dependency requires compilation (e.g., a C extension without wheels), we may need to revert to a multi-stage build or install `build-essential` in the image. For the current dependency set (FastAPI, SQLAlchemy, Alembic, toolz), all packages provide wheels, so single-stage is safe.

## AI Summary (optional)

Migrated the project's Dockerfile from Poetry to uv, replacing a broken multi-stage build (which referenced a non-existent `poetry.lock`) with a working single-stage build that installs dependencies from `uv.lock`. Updated README and internal docs to remove outdated Poetry references and reflect the new container workflow.
